### PR TITLE
modules: interface: return None if speed not defined

### DIFF
--- a/testinfra/modules/interface.py
+++ b/testinfra/modules/interface.py
@@ -62,8 +62,9 @@ class LinuxInterface(Interface):
 
     @property
     def speed(self):
-        return int(self.check_output(
-            "cat /sys/class/net/%s/speed", self.name))
+        speed = self.run("cat /sys/class/net/%s/speed", self.name)
+        if speed.rc == 0:
+            return int(speed.stdout)
 
     @property
     def addresses(self):


### PR DESCRIPTION
On Linux, some interfaces don't have a speed attribute, such as `lo` for
instance. In that case, `cat /sys/class/net/lo/speed` returns:

  cat: /sys/class/net/lo/speed: Invalid argument

which causes Interface.speed to throw an exception.

This commit makes Interface.speed return None in those cases, instead of
throwing an AssertionError.