### PR TITLE
Decode issues when using salt host

### DIFF
--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -257,6 +257,8 @@ class BaseBackend(object):
             return data.decode("ascii")
         except UnicodeDecodeError:
             return data.decode(self.encoding)
+        except AttributeError:
+            return data
 
     def encode(self, data):
         try:

--- a/testinfra/modules/socket.py
+++ b/testinfra/modules/socket.py
@@ -230,7 +230,10 @@ class LinuxSocketSS(Socket):
             # Ignore unix datagram sockets.
             if line.split(None, 1)[0] == b'u_dgr':
                 continue
-            splitted = line.decode().split()
+            try:
+                splitted = line.decode().split()
+            except AttributeError:
+                splitted = line.split()
 
             # If listing only TCP or UDP sockets, output has 5 columns:
             # (State, Recv-Q, Send-Q, Local Address:Port, Peer Address:Port)


### PR DESCRIPTION
Command run
`/opt/pytest/bin/py.test -v --host="salt://master-*" /opt/terraform/test/salt/test_infra/test.py`

Content of /opt/terraform/test/salt/test_infra/test.py
```
def test_salt_master(host):
    assert host.socket("tcp://:::4506").is_listening

def test_salt_clients_minions(host):
    assert len(json.loads(host.run("salt-run --out-indent=-1 --out=json manage.up minion-*").stdout)) == count_minion
```

Expected : Test Passed

Result :

```def test_salt_master(host):
>       assert host.socket("tcp://:::4506").is_listening

/opt/terraform/test/salt/test_infra/test_splunk_network.py:7: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/opt/pytest/lib/python3.4/site-packages/testinfra/modules/socket.py:112: in is_listening
    sockets = list(self._iter_sockets(True))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <socket tcp://:::4506>, listening = True

    def _iter_sockets(self, listening):
        cmd = '%s --numeric'
        if listening:
            cmd += ' --listening'
        else:
            cmd += ' --all'
        if self.protocol == 'tcp':
            cmd += ' --tcp'
        elif self.protocol == 'udp':
            cmd += ' --udp'
        elif self.protocol == 'unix':
            cmd += ' --unix'
    
        for line in self.run(cmd, self._command).stdout_bytes.splitlines()[1:]:
            # Ignore unix datagram sockets.
            if line.split(None, 1)[0] == b'u_dgr':
                continue
>           splitted = line.decode().split()
E           AttributeError: 'str' object has no attribute 'decode'
```


```
host = <testinfra.host.Host object at 0x7f219facf0f0>

    def test_salt_clients_master(host):
>       assert len(json.loads(host.run("salt-run --out-indent=-1 --out=json manage.up master-*").stdout)) == 1

/opt/terraform/test/salt/test_infra/test_splunk_network.py:14: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/opt/pytest/lib/python3.4/site-packages/testinfra/backend/base.py:77: in stdout
    self._stdout = self._backend.decode(self._stdout_bytes)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <testinfra.backend.salt.SaltBackend object at 0x7f219fae9208>, data = '["master-salt-689012b2ca3ff805df1d0cff218e18d2d372db887d1158dfd6dec934b9658cf7"]'

    def decode(self, data):
        try:
>           return data.decode("ascii")
E           AttributeError: 'str' object has no attribute 'decode'

/opt/pytest/lib/python3.4/site-packages/testinfra/backend/base.py:257: AttributeError
```
