### PR TITLE
Salt host matching issue

### DIFF
--- a/testinfra/backend/salt.py
+++ b/testinfra/backend/salt.py
@@ -48,11 +48,11 @@ class SaltBackend(base.BaseBackend):
         out = self.client.cmd(self.host, func, args or [])
         hosts = SaltBackend.get_hosts(self.host)
         delta = set(hosts) - set(out.keys())
-        if len(delta) > 0:
+        if delta:
             raise RuntimeError(
                 "Error while running %s(%s): %s. Minion not connected ?" % (
                     func, args, out))
-        return {key:out[key] for key in out.keys() if key in hosts}
+        return { key: out[key] for key in out.keys() if key in hosts }
 
     @classmethod
     def get_hosts(cls, host, **kwargs):

--- a/testinfra/backend/salt.py
+++ b/testinfra/backend/salt.py
@@ -46,7 +46,7 @@ class SaltBackend(base.BaseBackend):
 
     def run_salt(self, func, args=None):
         out = self.client.cmd(self.host, func, args or [])
-        hosts = SaltBackend.get_hosts(self.host))
+        hosts = SaltBackend.get_hosts(self.host)
         delta = set(hosts) - set(out.keys())
         if len(delta) > 0:
             raise RuntimeError(

--- a/testinfra/backend/salt.py
+++ b/testinfra/backend/salt.py
@@ -52,7 +52,7 @@ class SaltBackend(base.BaseBackend):
             raise RuntimeError(
                 "Error while running %s(%s): %s. Minion not connected ?" % (
                     func, args, out))
-        return { key: out[key] for key in out.keys() if key in hosts }
+        return {key: out[key] for key in out.keys() if key in hosts}
 
     @classmethod
     def get_hosts(cls, host, **kwargs):

--- a/testinfra/backend/salt.py
+++ b/testinfra/backend/salt.py
@@ -46,11 +46,13 @@ class SaltBackend(base.BaseBackend):
 
     def run_salt(self, func, args=None):
         out = self.client.cmd(self.host, func, args or [])
-        if self.host not in out:
+        hosts = SaltBackend.get_hosts(self.host))
+        delta = set(hosts) - set(out.keys())
+        if len(delta) > 0:
             raise RuntimeError(
                 "Error while running %s(%s): %s. Minion not connected ?" % (
                     func, args, out))
-        return out[self.host]
+        return {key:out[key] for key in out.keys() if key in hosts}
 
     @classmethod
     def get_hosts(cls, host, **kwargs):


### PR DESCRIPTION
Running:
``` 
>>> d= get_host("salt://*")
>>> d.salt("pkg.version", "python-34")
```
Produced
```
RuntimeError: Error while running pkg.version(['python34']): {'minion-salt-689012b2ca3ff805df1d0cff218e18d2d372db887d1158dfd6dec934b9658cf7': '3.4.9-1.el7', 'master-salt-689012b2ca3ff805df1d0cff218e18d2d372db887d1158dfd6dec934b9658cf7': '3.4.9-1.el7'}. Minion not connected ?
```
