### PR TITLE
Create a context manager for changing current working directory

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -468,6 +468,11 @@ def test_command_execution(host):
     assert host.run("true").succeeded
 
 
+def test_command_execution_in_chdir(host):
+    assert host.run("pwd", cwd='/tmp').stdout.strip() == '/tmp'
+    assert host.run("pwd").stdout.strip() != '/tmp'
+
+
 def test_pip_package(host):
     assert host.pip_package.get_packages()['pip']['version'] == '9.0.1'
     pytest = host.pip_package.get_packages(pip_path='/v/bin/pip')['pytest']

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -192,7 +192,7 @@ class BaseBackend(object):
     def run(self, command, *args, **kwargs):
         raise NotImplementedError
 
-    def run_local(self, command, *args):
+    def run_local(self, command, *args, **kwargs):
         command = self.quote(command, *args)
         command = self.encode(command)
         p = subprocess.Popen(
@@ -200,6 +200,7 @@ class BaseBackend(object):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            **kwargs
         )
         stdout, stderr = p.communicate()
         result = self.result(p.returncode, command, stdout, stderr)

--- a/testinfra/backend/local.py
+++ b/testinfra/backend/local.py
@@ -30,4 +30,4 @@ class LocalBackend(base.BaseBackend):
         return [host]
 
     def run(self, command, *args, **kwargs):
-        return self.run_local(self.get_command(command, *args))
+        return self.run_local(self.get_command(command, *args), **kwargs)


### PR DESCRIPTION
Hello,

I have a use-case which doesn't quite work in testinfra as it stands.

host.run() on a local host eventually calls subprocess.run().  That's great, but I noticed it doesn't pass **kwargs.  The fix is trivial, but I've no idea:

* if this implementation of the fix is acceptable
* what it breaks outside my use case.

I added a test, which fails in docker (see below).  I haven't started digging in yet because I thought I'd check first if this whole idea was a non-starter?

```
test/test_modules.py::test_command_execution_in_chdir[docker://debian_stretch] 
[gw1] [ 93%] FAILED test/test_modules.py::test_command_execution_in_chdir[docker://debian_stretch] 

    def test_command_execution_in_chdir(host):
>       assert host.run("pwd", cwd='/tmp').stdout.strip() == '/tmp'
E       AssertionError: assert '/' == '/tmp'
E         - /
E         + /tmp
```