### PR TITLE
add check parameter to run

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -477,6 +477,13 @@ def test_command_execution(host):
     assert host.run("true").succeeded
 
 
+def test_run_check(host):
+    with pytest.raises(AssertionError) as err:
+        host.run("false", check=True)
+        expected_err = "Command 'false' returned non-zero exit status 1"
+        assert expected_err in str(err.value)
+
+
 def test_pip_package(host):
     assert host.pip_package.get_packages()['pip']['version'] == '9.0.1'
     pytest = host.pip_package.get_packages(pip_path='/v/bin/pip')['pytest']

--- a/testinfra/host.py
+++ b/testinfra/host.py
@@ -71,8 +71,21 @@ class Host(object):
             stderr=(
               'ls: cannot access /;echo inject: No such file or directory\\n'),
             command="ls -l '/;echo inject'")
+
+
+        You can use the 'check' parameter to fail with an AssertionError
+        when a command fails
+
+
+        >>> host.run("false", check=True)
+        AssertionError("Command 'false' returned non-zero exit status 1.")
         """
-        return self.backend.run(command, *args, **kwargs)
+        result = self.backend.run(command, *args, **kwargs)
+        if "check" in kwargs:
+            assert result.succeeded, (
+                "Command '%s' returned non-zero exit status %d." %
+                (command, result.rc))
+        return result
 
     def run_expect(self, expected, command, *args, **kwargs):
         """Run command and check it return an expected exit status


### PR DESCRIPTION
Provide similar functionality like the [`subprocess.run(...)`](https://docs.python.org/3/library/subprocess.html#subprocess.run) command with the `check` parameter to raise an exception when the command failed to execute. This is useful when a command is not the test itself but used to prepare a test and you don't want to use an assert statement for every command.
Also I think this is more convenient than the `host.run_expect([0], ...)` command.