### PR TITLE
Add support for Windows files and services to TestInfra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ flake8.report
 junit*.xml
 doc/build
 .cache
+.idea

--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -14,6 +14,7 @@
 import collections
 import locale
 import logging
+import os
 import pipes
 import subprocess
 import urllib.parse
@@ -189,7 +190,11 @@ class BaseBackend(object):
 
     def run_local(self, command, *args):
         command = self.quote(command, *args)
-        command = self.encode(command)
+
+        # Subprocess doesn't like working on Bytes in Windows.
+        # See "list2cmdline" within subprocess for details
+        if os.name != 'nt':
+            command = self.encode(command)
         p = subprocess.Popen(
             command, shell=True,
             stdin=subprocess.PIPE,

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -189,6 +189,8 @@ class File(Module):
             return BSDFile
         if host.system_info.type == "darwin":
             return DarwinFile
+        if host.system_info.type == "windows":
+            return WindowsFile
         raise NotImplementedError
 
 
@@ -303,3 +305,159 @@ class NetBSDFile(BSDFile):
     def sha256sum(self):
         return self.check_output(
             "cksum -a sha256 < %s", self.path)
+
+
+class WindowsFile(File):
+    @property
+    def exists(self):
+        """Test if file exists
+        >>> host.file(r"C:/Users").exists
+        True
+        >>> host.file(r"C:/nonexistent").exists
+        False
+        """
+        return self.check_output("powershell -command \"Test-Path %s\"", self.path) == "True"
+
+    @property
+    def is_file(self):
+        return self.check_output("powershell -command \"(Get-Item %s) -is [System.IO.FileInfo]\"", self.path) == "True"
+
+    @property
+    def is_directory(self):
+        return self.check_output("powershell -command \"(Get-Item %s) -is [System.IO.DirectoryInfo]\"", self.path) == "True"
+
+    @property
+    def is_pipe(self):
+        raise NotImplementedError
+
+    @property
+    def is_socket(self):
+        raise NotImplementedError
+
+    @property
+    def is_symlink(self):
+        raise NotImplementedError
+
+    @property
+    def linked_to(self):
+        """Resolve symlink
+
+        >>> host.file("/var/lock").linked_to
+        '/run/lock'
+        """
+        raise NotImplementedError
+
+    @property
+    def user(self):
+        """Return file owner as string
+
+        >>> host.file("/etc/passwd").user
+        'root'
+        """
+        raise NotImplementedError
+
+    @property
+    def uid(self):
+        """Return file user id as integer
+
+        >>> host.file("/etc/passwd").uid
+        0
+        """
+        raise NotImplementedError
+
+    @property
+    def group(self):
+        raise NotImplementedError
+
+    @property
+    def gid(self):
+        raise NotImplementedError
+
+    @property
+    def mode(self):
+        """Return file mode as octal integer
+
+        >>> host.file("/etc/passwd").mode
+        384  # 0o600 (octal)
+        >>> host.file("/etc/password").mode == 0o600
+        True
+        >>> oct(host.file("/etc/password").mode) == '0600'
+        True
+
+        Note: Python 3 oct(x)_ function will produce ``'0o600'``
+
+        You can also utilize the file mode constants from
+        the stat_ library for testing file mode.
+
+        >>> import stat
+        >>> host.file("/etc/password").mode == stat.S_IRUSR | stat.S_IWUSR
+        True
+
+        .. _oct(x): https://docs.python.org/3.5/library/functions.html#oct
+        .. _stat: https://docs.python.org/2/library/stat.html
+        """
+        raise NotImplementedError
+
+    def contains(self, pattern):
+        return self.run_test("grep -qs -- %s %s", pattern, self.path).rc == 0
+
+    @property
+    def md5sum(self):
+        raise NotImplementedError
+
+    @property
+    def sha256sum(self):
+        raise NotImplementedError
+
+    def _get_content(self, decode):
+        out = self.run_test("cat -- %s", self.path)
+        if out.rc != 0:
+            raise RuntimeError("Unexpected output %s" % (out,))
+        if decode:
+            return out.stdout
+        return out.stdout_bytes
+
+    @property
+    def content(self):
+        """Return file content as bytes
+
+        >>> host.file("/tmp/foo").content
+        b'caf\\xc3\\xa9'
+        """
+        return self._get_content(False)
+
+    @property
+    def content_string(self):
+        """Return file content as string
+
+        >>> host.file("/tmp/foo").content_string
+        'café'
+        """
+        return self._get_content(True)
+
+    @property
+    def mtime(self):
+        """Return time of last modification as datetime.datetime object
+
+        >>> host.file("/etc/passwd").mtime
+        datetime.datetime(2015, 3, 15, 20, 25, 40)
+        """
+        raise NotImplementedError
+
+    @property
+    def size(self):
+        """Return size of file in bytes"""
+        raise NotImplementedError
+
+    def __repr__(self):
+        return "<file %s>" % (self.path,)
+
+    def __eq__(self, other):
+        if isinstance(other, File):
+            return self.path == other.path
+        if isinstance(other, six.string_types):
+            return self.path == other
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 
 import datetime
+import six
+
 
 from testinfra.modules.base import Module
 
@@ -311,20 +313,28 @@ class WindowsFile(File):
     @property
     def exists(self):
         """Test if file exists
+
         >>> host.file(r"C:/Users").exists
         True
+
         >>> host.file(r"C:/nonexistent").exists
         False
         """
-        return self.check_output("powershell -command \"Test-Path %s\"", self.path) == "True"
+
+        return self.check_output(
+            "powershell -command \"Test-Path %s\"", self.path) == "True"
 
     @property
     def is_file(self):
-        return self.check_output("powershell -command \"(Get-Item %s) -is [System.IO.FileInfo]\"", self.path) == "True"
+        return self.check_output(
+            "powershell -command \"(Get-Item %s) -is [System.IO.FileInfo]\"",
+            self.path) == "True"
 
     @property
     def is_directory(self):
-        return self.check_output("powershell -command \"(Get-Item %s) -is [System.IO.DirectoryInfo]\"", self.path) == "True"
+        return self.check_output(
+            "powershell -command \"(Get-Item %s) -is [System.IO.DirectoryInfo]\"",  # noqa: E501
+            self.path) == "True"
 
     @property
     def is_pipe(self):

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -65,6 +65,8 @@ class Service(Module):
             return OpenBSDService
         if host.system_info.type == "netbsd":
             return NetBSDService
+        if host.system_info.type == "windows":
+            return WindowsService
         raise NotImplementedError
 
     def __repr__(self):
@@ -215,3 +217,16 @@ class NetBSDService(Service):
     @property
     def is_enabled(self):
         raise NotImplementedError
+
+
+class WindowsService(Service):
+
+    @property
+    def is_running(self):
+        return self.check_output(
+            'powershell -command "Get-Service \"%s\" | Select -ExpandProperty Status"', self.name) == "Running"
+
+    @property
+    def is_enabled(self):
+        return self.check_output(
+            'powershell -command "Get-Service \"%s\" | Select -ExpandProperty StartType"', self.name) == "Automatic"

--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -224,9 +224,11 @@ class WindowsService(Service):
     @property
     def is_running(self):
         return self.check_output(
-            'powershell -command "Get-Service \"%s\" | Select -ExpandProperty Status"', self.name) == "Running"
+            'powershell -command "Get-Service \"%s\" | Select -ExpandProperty Status"',  # noqa: E501
+            self.name) == "Running"
 
     @property
     def is_enabled(self):
         return self.check_output(
-            'powershell -command "Get-Service \"%s\" | Select -ExpandProperty StartType"', self.name) == "Automatic"
+            'powershell -command "Get-Service \"%s\" | Select -ExpandProperty StartType"',  # noqa: E501
+            self.name) == "Automatic"


### PR DESCRIPTION
This PR, which also contains changes in https://github.com/philpep/testinfra/pull/480 which we needed to get testinfra to work on windows, adds support for Windows files and services, allowing tests to be written against these objects.

I was having trouble running the tests (they seem to require a French locale), so I'm hoping Travis will check this PR