### PR TITLE
Added the ability to get ansible settings from environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ flake8.report
 junit*.xml
 doc/build
 .cache
+.vscode/

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -55,7 +55,7 @@ def get_ansible_inventory(config, inventory_file):
     return json.loads(local.check_output(cmd, *args))
 
 
-class AnsibleKeys:
+class AnsibleKeys(object):
     ansible_host = 'ansible_host'
     ansible_user = 'ansible_user'
     ansible_ssh_pass = 'ansible_ssh_pass'
@@ -122,7 +122,7 @@ def get_ansible_host(config, inventory, host, ssh_config=None,
 
     elif AnsibleKeys.ansible_private_key_file in hostvars:
         kwargs[AnsibleKeys.ssh_identity_file] = hostvars[
-            AnsibleKeys.ssh_identity_file]
+            AnsibleKeys.ansible_private_key_file]
 
     kwargs[AnsibleKeys.ssh_extra_args] = '{} {}'.format(
         hostvars.get(AnsibleKeys.ansible_ssh_common_args, ''),

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -77,12 +77,6 @@ class AnsibleKeys(object):
 
 
 def get_ansible_config_provider(inventory, host):
-    """
-    Gets the data source for ansible
-    :param inventory:
-    :param host:
-    :return:
-    """
     provider = inventory['_meta'].get('hostvars', {}).get(host, {})
 
     if os.environ.get("ANSBILE_FROM_ENV"):

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -75,14 +75,36 @@ def get_ansible_host(config, inventory, host, ssh_config=None,
         'paramiko_ssh': 'paramiko',
         'smart': 'ssh',
     }.get(connection, connection)
+
     testinfra_host = hostvars.get('ansible_host', host)
-    user = hostvars.get('ansible_user')
-    password = hostvars.get('ansible_ssh_pass')
+
+    user = os.environ.get(
+        'ansible_user',
+        hostvars.get('ansible_user')
+    )
+
+    ansible_become_user = os.environ.get(
+        'ansible_become_user',
+        hostvars.get('ansible_become_user')
+    )
+
+    password = os.environ.get(
+        'ansible_ssh_pass',
+        hostvars.get('ansible_ssh_pass')
+    )
+
+    sudo = os.environ.get(
+        'ansible_become',
+        hostvars.get('ansible_become', False)
+    )
+
     port = hostvars.get('ansible_port')
+
     kwargs = {}
-    if hostvars.get('ansible_become', False):
-        kwargs['sudo'] = True
-    kwargs['sudo_user'] = hostvars.get('ansible_become_user')
+    kwargs['sudo'] = sudo
+
+    kwargs['sudo_user'] = ansible_become_user
+
     if ssh_config is not None:
         kwargs['ssh_config'] = ssh_config
     if ssh_identity_file is not None:

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -76,13 +76,30 @@ class AnsibleKeys(object):
     ansible_ssh_extra_args = 'ansible_ssh_extra_args'
 
 
+def get_ansible_config_provider(inventory, host):
+    """
+    Gets the data source for ansible
+    :param inventory:
+    :param host:
+    :return:
+    """
+    provider = inventory['_meta'].get('hostvars', {}).get(host, {})
+
+    if os.environ.get("ANSBILE_FROM_ENV"):
+        provider = os.environ
+
+    return provider
+
+
 def get_ansible_host(config, inventory, host, ssh_config=None,
                      ssh_identity_file=None):
     if is_empty_inventory(inventory):
         if host == 'localhost':
             return testinfra.get_host('local://')
         return None
-    hostvars = inventory['_meta'].get('hostvars', {}).get(host, {})
+
+    hostvars = get_ansible_config_provider(inventory=inventory, host=host)
+
     connection = hostvars.get('ansible_connection', 'ssh')
     if connection not in (
         'smart', 'ssh', 'paramiko_ssh', 'local', 'docker', 'lxc', 'lxd',


### PR DESCRIPTION
Tools
* terraform
* gitlab-ci
* terraform-inventory

Motivation
So, as I use terraforms to manage the server life cycle, my project does not have a “static” inventory file. Inventory file I get using terraform-inventory. For example like this 
```
- ansible-playbook --inventory=/usr/local/bin/terraform-inventory ${ansible_service_path}
```

At this moment, by using this library, there is no functionality to instantly redefine any variable or its value, there is only ansible-cli functionality, but it's not enough. In  my pull-request there is a functional which may not be suitable for everyone, but it helps to prepare and launch tests more flexibly. For example, tests in my project look like this:

ansible/roles/kibana/tasks/mail.yml

```
- name: put elasticsearch.repo
  copy:
    src: elasticsearch.repo
    dest: /etc/yum.repos.d/elasticsearch.repo
    owner: root
    group: root
    mode: '644'
  when: action == "install"

- yum:
    name: "{{ packages }}"
    update_cache: yes
    state: present
    enablerepo: "elasticsearch"
  register: elasticinstalled
  name: installs kibana
  when: action == "install"
```

main.tf

```
resource "openstack_compute_instance_v2" "kibana_server" {
  name        = "kibana_server"
  flavor_name = var.flavor_name

  key_pair = var.key_pair_name

  security_groups = [
    data.consul_keys.consul_sg.var.id,
    data.consul_keys.ssh_sg.var.id,
    openstack_compute_secgroup_v2.kibana_sg.id
  ]

  availability_zone = var.region

  network {
    uuid = var.network_id
  }

  block_device {
    uuid                  = openstack_blockstorage_volume_v1.kibana_server_volume.id
    source_type           = "volume"
    boot_index            = 0
    destination_type      = "volume"
    delete_on_termination = true
  }

}
```

variables.tf
```
variable "image_name" {
  default = "CentOS-7.4-Standard"
}

variable "flavor_name" {
  default = "Standard-2-4-50"
}

variable "ssh_user_name" {
  default = "centos"
}
```

.gitlab-ci.yml
```
test-infra:
  stage: test
  variables:
    ANSBILE_FROM_ENV: 'true'
    ansible_user: centos
    ansible_become_user: centos
    ansible_become: 'true'
    ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
    ansible_ssh_extra_args: '-o StrictHostKeyChecking=no'
  script:
   - terraform init -input=false
   - terraform apply -auto-approve -input=false
   - terraform-inventory -inventory ./ >> inventory/test-${CI_PIPELINE_ID}
   - ansible-playbook --inventory=inventory/test-${CI_PIPELINE_ID} -e "action=install"
   - make pytest ROLE_NAME=kibana INVENT_FILE=inventory/test-${CI_PIPELINE_ID}
  after_script:
    - terraform destroy -auto-approve
  tags:
    - bastion-mcs
```