### PR TITLE
service-module: use /run/systemd/system/ to detect systemd (fixes #546)

### DIFF
--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -45,7 +45,7 @@ class Service(Module):
     @classmethod
     def get_module_class(cls, host):
         if host.system_info.type == "linux":
-            if (
+            if host.file("/run/systemd/system/").is_directory or (
                 host.exists("systemctl")
                 and "systemd" in host.file("/sbin/init").linked_to
             ):


### PR DESCRIPTION
I couldn't quite get the unit tests working. I'll leave that to Travis. The change is designed to not break anything :-)