### PR TITLE
Fix #398 `salt` backend returning non-encoded strings

### DIFF
--- a/testinfra/backend/salt.py
+++ b/testinfra/backend/salt.py
@@ -37,8 +37,12 @@ class SaltBackend(base.BaseBackend):
     def run(self, command, *args, **kwargs):
         command = self.get_command(command, *args)
         out = self.run_salt("cmd.run_all", [command])
-        return self.result(out['retcode'], command, out['stdout'],
-                           out['stderr'])
+
+        return self.result(out['retcode'], command,
+                           out['stdout'].encode('utf8'),
+                           out['stderr'].encode('utf8'),
+                           stdout=out['stdout'],
+                           stderr=out['stderr'],)
 
     def run_salt(self, func, args=None):
         out = self.client.cmd(self.host, func, args or [])


### PR DESCRIPTION
`salt` backend failed because local salt client returns
`stdout` and `stderr` as `str` objects not encoded `bytes`.

Taking a lead from the `ansible` implementation the `stdout` and
`stderr` results are both encoded and returned as `kwargs` through
`base.result` method.