### PR TITLE
utils/ansible_runner: Use ssh_args from ansible.cfg

### DIFF
--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -98,10 +98,11 @@ def get_ansible_host(config, inventory, host, ssh_config=None,
     elif 'ansible_private_key_file' in hostvars:
         kwargs['ssh_identity_file'] = hostvars[
             'ansible_private_key_file']
-    kwargs['ssh_extra_args'] = '{} {}'.format(
+    kwargs['ssh_extra_args'] = ' '.join([
+        config.get('ssh_connection', 'ssh_args', fallback=''),
         hostvars.get('ansible_ssh_common_args', ''),
         hostvars.get('ansible_ssh_extra_args', '')
-    ).strip()
+    ]).strip()
 
     spec = '{}://'.format(connection)
 


### PR DESCRIPTION
If `ssh_args` is set in Ansible's configuration file, use those arguments when
connecting to hosts.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>