### PR TITLE
backend: Deduplicate hosts returned by get_backends()

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -519,3 +519,16 @@ def test_ssh_hostspec(hostspec, expected):
     cmd, cmd_args = backend._build_ssh_command('true')
     command = backend.quote(' '.join(cmd), *cmd_args)
     assert command == expected
+
+
+def test_get_hosts():
+    # Hosts returned by get_host must be deduplicated (by name & kwargs) and in
+    # same order as asked
+    hosts = testinfra.backend.get_backends([
+        'ssh://foo', 'ssh://a', 'ssh://a', 'ssh://a?timeout=1',
+    ])
+    assert [(h.host.name, h.timeout) for h in hosts] == [
+        ('foo', 10),
+        ('a', 10),
+        ('a', 1),
+    ]

--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -77,7 +77,7 @@ def get_backend(hostspec, **kwargs):
 
 
 def get_backends(hosts, **kwargs):
-    backends = []
+    backends = {}
     for hostspec in hosts:
         host, kw = parse_hostspec(hostspec)
         for k, v in kwargs.items():
@@ -89,8 +89,12 @@ def get_backends(hosts, **kwargs):
             connection = "paramiko"
         klass = get_backend_class(connection)
         for name in klass.get_hosts(host, **kw):
+            key = (name, frozenset(kw.items()))
+            if key in backends:
+                continue
             if connection == "local":
-                backends.append(klass(**kw))
+                backend = klass(**kw)
             else:
-                backends.append(klass(name, **kw))
-    return backends
+                backend = klass(name, **kw)
+            backends[key] = backend
+    return list(backends.values())


### PR DESCRIPTION
If a host appears multiple times in host specs (which can typically happen if a
host is a member of multiple Ansible groups for instance), testinfra would run
tests on that host multiple times.

This commit turns the list of hosts that are being considered into a set, and
makes each one of them hashable in such a way that two hosts are considered
equal if they have the same name, connection parameters, etc.

As a result, if a host finds itself listed multiple times with the same backend
and connection parameters, testinfra will run the tests on that host only once.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>