### PR TITLE
Fix module class for RPM and Debian distributions #570

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -85,7 +85,6 @@ def test_non_default_package_tool(host):
     # Make non default pkg tool binary present
     host.run("install -m a+rx /bin/true /usr/bin/dpkg-query")
     # drop the cache
-    del host.package
     assert host.package("openssh").is_installed
 
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -31,6 +31,13 @@ all_images = pytest.mark.testinfra_hosts(*[
     )
 ])
 
+centos_images = pytest.mark.testinfra_hosts(*[
+    "docker://{}".format(image)
+    for image in (
+        "centos_6", "centos_7",
+    )
+])
+
 
 @all_images
 def test_package(host, docker_image):
@@ -73,6 +80,16 @@ def test_held_package(host):
 
 
 @pytest.mark.destructive
+@centos_images
+def test_non_default_package_tool(host):
+    # Make non default pkg tool binary present
+    host.run("install -m a+rx /bin/true /usr/bin/dpkg-query")
+    # drop the cache
+    del host.package
+    assert host.package("openssh").is_installed
+
+
+@pytest.mark.destructive
 def test_uninstalled_package_version(host):
     with pytest.raises(AssertionError) as excinfo:
         host.package('zsh').version
@@ -93,7 +110,7 @@ def test_systeminfo(host, docker_image):
     release, distribution, codename, arch = {
         "alpine": (r"^3\.11\.", "alpine", None, 'x86_64'),
         "archlinux": ("rolling", "arch", None, 'x86_64'),
-        "centos_6": (r"^6", "CentOS", None, 'x86_64'),
+        "centos_6": (r"^6", "centos", None, 'x86_64'),
         "centos_7": (r"^7$", "centos", None, 'x86_64'),
         "debian_buster": (r"^10", "debian", "buster", 'x86_64'),
         "ubuntu_xenial": (r"^16\.04$", "ubuntu", "xenial", 'x86_64')

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -84,7 +84,6 @@ def test_held_package(host):
 def test_non_default_package_tool(host):
     # Make non default pkg tool binary present
     host.run("install -m a+rx /bin/true /usr/bin/dpkg-query")
-    # drop the cache
     assert host.package("openssh").is_installed
 
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -110,7 +110,7 @@ def test_systeminfo(host, docker_image):
     release, distribution, codename, arch = {
         "alpine": (r"^3\.11\.", "alpine", None, 'x86_64'),
         "archlinux": ("rolling", "arch", None, 'x86_64'),
-        "centos_6": (r"^6", "centos", None, 'x86_64'),
+        "centos_6": (r"^6", "CentOS", None, 'x86_64'),
         "centos_7": (r"^7$", "centos", None, 'x86_64'),
         "debian_buster": (r"^10", "debian", "buster", 'x86_64'),
         "ubuntu_xenial": (r"^16\.04$", "ubuntu", "xenial", 'x86_64')

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -68,14 +68,22 @@ class Package(Module):
             return FreeBSDPackage
         if host.system_info.type in ("openbsd", "netbsd"):
             return OpenBSDPackage
+        if host.system_info.distribution in ("debian", "ubuntu"):
+            return DebianPackage
+        if (
+            host.system_info.distribution
+            and host.system_info.distribution.lower() == "centos"
+        ):
+            return RpmPackage
+        if host.system_info.distribution == "arch":
+            return ArchPackage
+        if host.exists("apk"):
+            return AlpinePackage
+        # Fallback conditions
         if host.exists("dpkg-query"):
             return DebianPackage
         if host.exists("rpm"):
             return RpmPackage
-        if host.exists("apk"):
-            return AlpinePackage
-        if host.system_info.distribution == "arch":
-            return ArchPackage
         raise NotImplementedError
 
 


### PR DESCRIPTION
A CentOS system with dpkg package installed fails for all packages
is_installed checks. This happens because the decision to use the module class
is based on the presence of `dpkg-query` binary.

This commit changes the check to look for `system_info.distribution`, and
makes CentOS 6 distribution name lower case to be consistent.