### PR TITLE
Allow to run invocation tests without testinfra installed

### DIFF
--- a/test/test_invocation.py
+++ b/test/test_invocation.py
@@ -13,25 +13,34 @@
 pytest_plugins = ['pytester']
 
 
-def test_nagios_notest(testdir):
-    result = testdir.runpytest('--nagios', '-q', '--tb=no')
+def test_nagios_notest(testdir, request):
+    params = ['--nagios', '-q', '--tb=no']
+    if not request.config.pluginmanager.hasplugin('pytest11.testinfra'):
+        params.extend(['-p', 'testinfra.plugin'])
+    result = testdir.runpytest(*params)
     assert result.ret == 0
     lines = result.stdout.str().splitlines()
     assert lines[0].startswith('TESTINFRA OK - 0 passed, 0 failed, 0 skipped')
 
 
-def test_nagios_ok(testdir):
+def test_nagios_ok(testdir, request):
     testdir.makepyfile('def test_ok(): pass')
-    result = testdir.runpytest('--nagios', '-q', '--tb=no')
+    params = ['--nagios', '-q', '--tb=no']
+    if not request.config.pluginmanager.hasplugin('pytest11.testinfra'):
+        params.extend(['-p', 'testinfra.plugin'])
+    result = testdir.runpytest(*params)
     assert result.ret == 0
     lines = result.stdout.str().splitlines()
     assert lines[0].startswith('TESTINFRA OK - 1 passed, 0 failed, 0 skipped')
     assert lines[1][0] == '.'
 
 
-def test_nagios_fail(testdir):
+def test_nagios_fail(testdir, request):
     testdir.makepyfile('def test_ok(): pass\ndef test_fail(): assert False')
-    result = testdir.runpytest('--nagios', '-q', '--tb=no')
+    params = ['--nagios', '-q', '--tb=no']
+    if not request.config.pluginmanager.hasplugin('pytest11.testinfra'):
+        params.extend(['-p', 'testinfra.plugin'])
+    result = testdir.runpytest(*params)
     assert result.ret == 2
     lines = result.stdout.str().splitlines()
     assert lines[0].startswith(


### PR DESCRIPTION
Allow to execute invocation tests from sources, without `testinfra` being installed, using for example:

    PYTHONPATH=. pytest test/test_invocation.py

Fix this error reported by @lyknode on [`#testinfra`](https://webchat.freenode.net/#bip) IRC channel:

    =============================== FAILURES ===============================
    __________________________ test_nagios_notest __________________________

    testdir = <Testdir local('/tmp/pytest-of-pilou/pytest/test_nagios_notest0')>

        def test_nagios_notest(testdir):
            result = testdir.runpytest('--nagios', '-q', '--tb=no')
    >       assert result.ret == 0
    E       assert 4 == 0
    E        +  where 4 = <RunResult ret=4 len(stdout.lines)=1 len(stderr.lines)=6 duration=0.06s>.ret

    src/testinfra/test/test_invocation.py:18: AssertionError
    ------------------------- Captured stderr call -------------------------
    ERROR: usage: pytest-3 [options] [file_or_dir] [file_or_dir] [...]
    pytest-3: error: unrecognized arguments: --nagios
      inifile: None
      rootdir: /tmp/pytest-of-pilou/pytest/test_nagios_notest0