### PR TITLE
Remove "encoding" parameter when binary mode is used

### DIFF
--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -167,7 +167,10 @@ class NagiosReporter:
 class SpooledTemporaryFile(tempfile.SpooledTemporaryFile):
 
     def __init__(self, *args, **kwargs):
-        self._out_encoding = kwargs['encoding']
+        if 'b' in kwargs.get('mode', 'b'):
+            self._out_encoding = kwargs.pop('encoding')
+        else:
+            self._out_encoding = kwargs.get('encoding')
         super().__init__(*args, **kwargs)
 
     def write(self, s):


### PR DESCRIPTION
Fix this exception:

    python3 -c "import sys; from testinfra.plugin import SpooledTemporaryFile;\
                SpooledTemporaryFile(encoding=sys.stdout.encoding).fileno()"
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/lib/python3.8/tempfile.py", line 839, in fileno
        self.rollover()
      File "/usr/lib/python3.8/tempfile.py", line 793, in rollover
        newfile = self._file = TemporaryFile(**self._TemporaryFileArgs)
      File "/usr/lib/python3.8/tempfile.py", line 744, in TemporaryFile
        return _io.open(fd, mode, buffering=buffering,
    ValueError: binary mode doesn't take an encoding argument