### PR TITLE
Add support for password based authorization with paramiko

### DIFF
--- a/testinfra/backend/paramiko.py
+++ b/testinfra/backend/paramiko.py
@@ -74,6 +74,7 @@ class ParamikoBackend(base.BaseBackend):
             "port": int(self.host.port) if self.host.port else 22,
             "username": self.host.user,
             "timeout": self.timeout,
+            "password": self.host.password,
         }
         if self.ssh_config:
             with open(self.ssh_config) as f:


### PR DESCRIPTION
Authorization with username and password is now possible.
The password attribute will now get passed to Paramiko. 
As I noticed it just seems to be a missing configuration value.
Users can now authenticate using connection strings like the following one:
```python
testinfra.get_host(F"paramiko://{username}:{password}@{address}:{port}")
```