### PR TITLE
require python >= 3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -28,7 +27,7 @@ classifiers =
 
 [options]
 use_scm_version = True
-python_requires = >=3.5
+python_requires = >=3.6
 packages = find:
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
3.5 is EOL and our code use f-strings.