### PR TITLE
Removing Test Python 3.5 Environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
   lint
-  py{35,36,37,38,39}
+  py{36,37,38,39}
   doc
   packaging
 


### PR DESCRIPTION
As of

https://www.python.org/dev/peps/pep-0478/

Python 3.5 has reached end-of-life. Removing it from the test environments to reflect this state.