### PR TITLE
Fix #590: Systeminfo doesn't resolve Windows correctly 

### DIFF
--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -15,6 +15,8 @@ import re
 from testinfra.modules.base import InstanceModule
 from testinfra.utils import cached_property
 
+import platform
+
 
 class SystemInfo(InstanceModule):
     """Return system informations"""
@@ -28,23 +30,22 @@ class SystemInfo(InstanceModule):
             "release": None,
             "arch": None,
         }
-        uname = self.run_expect([0, 1], 'uname -s')
-        if uname.rc == 1:
-            # FIXME: find a better way to detect windows here
-            sysinfo.update(**self._get_windows_sysinfo())
+        uname = platform.uname()
+        sysinfo["type"] = uname.system.lower()
+        if sysinfo["type"] == "windows":
+            sysinfo.update(**self._get_windows_sysinfo(uname))
             return sysinfo
-        sysinfo["type"] = uname.stdout.rstrip("\r\n").lower()
-        if sysinfo["type"] == "linux":
+        elif sysinfo["type"] == "linux":
             sysinfo.update(**self._get_linux_sysinfo())
         elif sysinfo["type"] == "darwin":
             sysinfo.update(**self._get_darwin_sysinfo())
         else:
             # BSD
-            sysinfo["release"] = self.check_output("uname -r")
+            sysinfo["release"] = uname.release
             sysinfo["distribution"] = sysinfo["type"]
             sysinfo["codename"] = None
 
-        sysinfo["arch"] = self.check_output("uname -m")
+        sysinfo["arch"] = uname.machine
         return sysinfo
 
     def _get_linux_sysinfo(self):
@@ -119,19 +120,11 @@ class SystemInfo(InstanceModule):
 
         return sysinfo
 
-    def _get_windows_sysinfo(self):
+    def _get_windows_sysinfo(self, uname):
         sysinfo = {}
-        for line in self.check_output(
-                "systeminfo | findstr /B /C:\"OS\"").splitlines():
-            key, value = line.split(":", 1)
-            key = key.strip().replace(' ', '_').lower()
-            value = value.strip()
-            if key == "os_name":
-                sysinfo["distribution"] = value
-                sysinfo["type"] = value.split(" ")[1].lower()
-            elif key == "os_version":
-                sysinfo["release"] = value
-        sysinfo["arch"] = self.check_output('echo %PROCESSOR_ARCHITECTURE%')
+        sysinfo["distribution"] = platform.win32_edition()
+        sysinfo["release"] = uname.version
+        sysinfo["arch"] = uname.machine
         return sysinfo
 
     @property

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
   lint
-  py{35,36,37,38,39}
+  py{36,37,38,39}
   doc
   packaging
 


### PR DESCRIPTION
This PR is to fix issue #590. It includes the platform module to resolve the OS type correctly. This enables tests running against `WinRM` to behave correctly if a MSYS2 is installed on the windows system.

It was tested against the current test suite.

Resolves: #590