### PR TITLE
Fix #594: mode documentation

### DIFF
--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -97,7 +97,7 @@ class File(Module):
         384  # 0o600 (octal)
         >>> host.file("/etc/password").mode == 0o600
         True
-        >>> oct(host.file("/etc/password").mode) == '0600'
+        >>> oct(host.file("/etc/password").mode) == '0o600'
         True
 
         Note: Python 3 oct(x)_ function will produce ``'0o600'``

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -93,25 +93,23 @@ class File(Module):
     def mode(self):
         """Return file mode as octal integer
 
-        >>> host.file("/etc/passwd").mode
-        384  # 0o600 (octal)
-        >>> host.file("/etc/password").mode == 0o600
+        >>> host.file("/etc/shadow").mode
+        416  # Oo640 octal
+        >>> host.file("/etc/shadow").mode == 0o640
         True
-        >>> oct(host.file("/etc/password").mode) == '0o600'
+        >>> oct(host.file("/etc/shadow").mode) == '0o640'
         True
-
-        Note: Python 3 oct(x)_ function will produce ``'0o600'``
 
         You can also utilize the file mode constants from
         the stat_ library for testing file mode.
 
         >>> import stat
-        >>> host.file("/etc/password").mode == stat.S_IRUSR | stat.S_IWUSR
+        >>> host.file("/etc/shadow").mode == stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP
         True
 
-        .. _oct(x): https://docs.python.org/3.5/library/functions.html#oct
-        .. _stat: https://docs.python.org/2/library/stat.html
-        """
+        .. _oct(x): https://docs.python.org/3/library/functions.html#oct
+        .. _stat: https://docs.python.org/3/library/stat.html
+        """  # noqa
         raise NotImplementedError
 
     def contains(self, pattern):


### PR DESCRIPTION
Hello,

Fix #594 a small issue in the `File.mode` documentation, see my [comment][1] in the issue for more detail.

Best.

[1]: https://github.com/pytest-dev/pytest-testinfra/issues/594#issuecomment-750370503