### PR TITLE
First implementation of network namespaces in addr module

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -588,3 +588,15 @@ def test_addr(host):
 
     for ip in google_addr.ip_addresses:
         assert isinstance(ip_address(ip), (IPv4Address, IPv6Address))
+
+
+@pytest.mark.testinfra_hosts("ansible://debian_buster")
+def test_addr_namespace(host):
+    namespace_lookup = host.addr("localhost", "ns1")
+    # ns1 network namespace does not exist so everything is false
+    assert not namespace_lookup.namespace_exists
+    assert not namespace_lookup.is_reachable
+    assert not namespace_lookup.is_resolvable
+    with pytest.raises(NotImplementedError):
+        # nc is not available so an error is raised
+        assert not namespace_lookup.port("443").is_reachable

--- a/testinfra/modules/addr.py
+++ b/testinfra/modules/addr.py
@@ -32,8 +32,8 @@ class _AddrPort:
                 "timeout 1 bash -c 'cat < /dev/null > /dev/tcp/%s/%s'",
                 self._addr.name, self._port).rc == 0
 
-        return self._addr.run("%snc -w 1 -z %s %s", self._addr._prefix,
-                              self._addr.name, self._port).rc == 0
+        return self._addr.run("{}nc -w 1 -z {} {}".format(self._addr._prefix,
+                              self._addr.name, self._port)).rc == 0
 
 
 class Addr(Module):


### PR DESCRIPTION
Hello,

Here is a try to resolve #559 by supporting network namespaces in the `addr` module.

It's not easy to test since it requires privileged mode in docker and it's not possible (as far as I know) to setup a namespace in a Docker image at build time. So I have only made some minimal test.

I'm not sure of the way to handle the case when `ip` command is not available. The current implementation throws immediately a `NotImplementedError` in this case.

Note: In some cases I've used the `format` method to format string since I had trouble using the classic `%` way. I don't know if it's a problem or if we need to stick to one convention.

Best.