### PR TITLE
docs: fix simple typo, underlaying -> underlying

### DIFF
--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -73,7 +73,7 @@ class BlockDevice(Module):
 
     @property
     def start_sector(self):
-        """Return start sector of the device on the underlaying device.
+        """Return start sector of the device on the underlying device.
 
            Usually the value is zero for full devices and is non-zero
            for partitions.


### PR DESCRIPTION
There is a small typo in testinfra/modules/blockdevice.py.

Should read `underlying` rather than `underlaying`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md