### PR TITLE
fix(tests): adding WSL2 support

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -208,17 +208,6 @@ def host(request, tmpdir_factory):
 
 
 @pytest.fixture
-def wsl(host):
-    return host.runs_on_wsl
-
-
-@pytest.fixture(autouse=True)
-def skip_if_wsl(request, wsl):
-    if request.node.get_closest_marker('skip_wsl'):
-        pytest.skip("Function not supported on WSL")
-
-
-@pytest.fixture
 def docker_image(host):
     return host.backend.get_hostname()
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -208,6 +208,17 @@ def host(request, tmpdir_factory):
 
 
 @pytest.fixture
+def wsl(host):
+    return host.runs_on_wsl
+
+
+@pytest.fixture(autouse=True)
+def skip_if_wsl(request, wsl):
+    if request.node.get_closest_marker('skip_wsl'):
+        pytest.skip("Function not supported on WSL")
+
+
+@pytest.fixture
 def docker_image(host):
     return host.backend.get_hostname()
 
@@ -263,4 +274,8 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "destructive: mark test as destructive"
+    )
+    config.addinivalue_line(
+        "markers",
+        "skip_wsl: skip test on WSL, no systemd support"
     )

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -12,10 +12,10 @@
 
 import crypt
 import datetime
-import re
-import time
 import os
 import pytest
+import re
+import time
 
 from ipaddress import ip_address
 from ipaddress import IPv4Address
@@ -516,8 +516,8 @@ def test_environment_home(host):
     assert host.environment().get('HOME') == '/root'
 
 
-skip_wsl = pytest.mark.skipif('WSL_DISTRO_NAME' in os.environ, reason="Skip on WSL (Windows Subsystem for Linux)")
-@skip_wsl
+@pytest.mark.skipif('WSL_DISTRO_NAME' in os.environ,
+                    reason="Skip on WSL (Windows Subsystem for Linux)")
 def test_iptables(host):
     cmd = host.run("systemctl start netfilter-persistent")
     assert cmd.exit_status == 0, f"{cmd.stdout}\n{cmd.stderr}"

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -516,6 +516,7 @@ def test_environment_home(host):
     assert host.environment().get('HOME') == '/root'
 
 
+@pytest.mark.skip_wsl()
 def test_iptables(host):
     cmd = host.run("systemctl start netfilter-persistent")
     assert cmd.exit_status == 0, f"{cmd.stdout}\n{cmd.stderr}"

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -14,7 +14,7 @@ import crypt
 import datetime
 import re
 import time
-
+import os
 import pytest
 
 from ipaddress import ip_address
@@ -516,7 +516,8 @@ def test_environment_home(host):
     assert host.environment().get('HOME') == '/root'
 
 
-@pytest.mark.skip_wsl()
+skip_wsl = pytest.mark.skipif('WSL_DISTRO_NAME' in os.environ, reason="Skip on WSL (Windows Subsystem for Linux)")
+@skip_wsl
 def test_iptables(host):
     cmd = host.run("systemctl start netfilter-persistent")
     assert cmd.exit_status == 0, f"{cmd.stdout}\n{cmd.stderr}"

--- a/testinfra/host.py
+++ b/testinfra/host.py
@@ -22,6 +22,7 @@ class Host:
 
     def __init__(self, backend):
         self.backend = backend
+        self.wsl_distro_name = os.getenv("WSL_DISTRO_NAME")
         super().__init__()
 
     def __repr__(self):
@@ -113,6 +114,10 @@ class Host:
             return obj
         raise AttributeError("'{}' object has no attribute '{}'".format(
             self.__class__.__name__, name))
+
+    @property
+    def runs_on_wsl(self):
+        return self.wsl_distro_name is not None
 
     @classmethod
     def get_host(cls, hostspec, **kwargs):

--- a/testinfra/host.py
+++ b/testinfra/host.py
@@ -22,7 +22,6 @@ class Host:
 
     def __init__(self, backend):
         self.backend = backend
-        self.wsl_distro_name = os.getenv("WSL_DISTRO_NAME")
         super().__init__()
 
     def __repr__(self):
@@ -114,10 +113,6 @@ class Host:
             return obj
         raise AttributeError("'{}' object has no attribute '{}'".format(
             self.__class__.__name__, name))
-
-    @property
-    def runs_on_wsl(self):
-        return self.wsl_distro_name is not None
 
     @classmethod
     def get_host(cls, hostspec, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps=
 commands=
     {envpython} -m pytest {posargs:-v -n 4 --cov testinfra --cov-report xml --cov-report term test}
 usedevelop=True
-passenv=HOME TRAVIS DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+passenv=HOME TRAVIS DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY WSL_DISTRO_NAME
 
 [testenv:lint]
 description = Performs linting tasks


### PR DESCRIPTION
Developers using WSL2 (Windows Subsystem for Linux) face the problem
that there is currently no systemd support. For the test `test_iptables`
a service is started and it fails on WSL2 hosts.

This commit introduces a pytest marker to skip the test if the host is
executing on WSL2.

With the skipped test the output of the tox run is

```bash
test/test_modules.py::test_iptables[docker://debian_buster]
[gw1] [ 94%] SKIPPED test/test_modules.py::test_iptables[docker://debian_buster]

180 passed, 1 skipped in 100.36s (0:01:40)
```