### PR TITLE
pip refactoring: implementation of installed and version

### DIFF
--- a/doc/source/modules.rst
+++ b/doc/source/modules.rst
@@ -58,6 +58,10 @@ host
 
        :class:`testinfra.modules.package.Package` class
 
+    .. attribute:: pip
+
+       :class:`testinfra.modules.pip.Pip` class
+
     .. attribute:: pip_package
 
        :class:`testinfra.modules.pip.PipPackage` class
@@ -182,11 +186,17 @@ Package
    :members:
 
 
+Pip
+~~~~~~~~~~
+
+.. autoclass:: testinfra.modules.pip.Pip
+   :members:
+
+
 PipPackage
 ~~~~~~~~~~
 
 .. autoclass:: testinfra.modules.pip.PipPackage
-   :members:
 
 
 Podman

--- a/testinfra/modules/__init__.py
+++ b/testinfra/modules/__init__.py
@@ -25,6 +25,7 @@ modules = {
     "iptables": "iptables:Iptables",
     "mount_point": "mountpoint:MountPoint",
     "package": "package:Package",
+    "pip": "pip:Pip",
     "pip_package": "pip:PipPackage",
     "process": "process:Process",
     "puppet_resource": "puppet:PuppetResource",

--- a/testinfra/modules/pip.py
+++ b/testinfra/modules/pip.py
@@ -39,7 +39,7 @@ class Pip(Module):
         >>> host.package("pip").is_installed
         True
         """
-        return self.run_test("{} show %s".format(self.pip_path), self.name).rc == 0
+        return self.run_test("%s show %s", self.pip_path, self.name).rc == 0
 
     @property
     def version(self):
@@ -49,7 +49,8 @@ class Pip(Module):
         '18.1'
         """
         return self.check_output(
-            "{} show %s | grep Version: | cut -d' ' -f2".format(self.pip_path),
+            "%s show %s | grep Version: | cut -d' ' -f2",
+            self.pip_path,
             self.name,
         )
 
@@ -69,8 +70,7 @@ class Pip(Module):
         .. _pip check: https://pip.pypa.io/en/stable/reference/pip_check/
         .. _9.0.0: https://pip.pypa.io/en/stable/news/#id526
         """
-        cmd = "{} check".format(pip_path)
-        return cls.run_expect([0, 1], cmd)
+        return cls.run_expect([0, 1], "%s check", pip_path)
 
     @classmethod
     def get_packages(cls, pip_path="pip"):
@@ -81,9 +81,7 @@ class Pip(Module):
          'mywebsite': {'version': '1.0a3', 'path': '/srv/website'},
          'psycopg2': {'version': '2.6.2'}}
         """
-        out = cls.run_expect(
-            [0, 2], "{0} list --no-index --format=json".format(pip_path)
-        )
+        out = cls.run_expect([0, 2], "%s list --no-index --format=json", pip_path)
         pkgs = {}
         if out.rc == 0:
             for pkg in json.loads(out.stdout):
@@ -92,9 +90,7 @@ class Pip(Module):
         else:
             # pip < 9
             output_re = re.compile(r"^(.+) \((.+)\)$")
-            for line in cls.check_output(
-                "{0} list --no-index".format(pip_path)
-            ).splitlines():
+            for line in cls.check_output("%s list --no-index", pip_path).splitlines():
                 if line.startswith("Warning: "):
                     # Warning: cannot find svn location for ...
                     continue
@@ -114,7 +110,7 @@ class Pip(Module):
         ...     pip_path='~/venv/website/bin/pip')
         {'Django': {'current': '1.10.2', 'latest': '1.10.3'}}
         """
-        out = cls.run_expect([0, 2], "{0} list -o --format=json".format(pip_path))
+        out = cls.run_expect([0, 2], "%s list -o --format=json", pip_path)
         pkgs = {}
         if out.rc == 0:
             for pkg in json.loads(out.stdout):
@@ -130,7 +126,7 @@ class Pip(Module):
                 re.compile(r"^(.+?) \((.+)\) - Latest: (.+) .*$"),
                 re.compile(r"^(.+?) \(Current: (.+) Latest: (.+) .*$"),
             ]
-            for line in cls.check_output("{0} list -o".format(pip_path)).splitlines():
+            for line in cls.check_output("%s list -o", pip_path).splitlines():
                 if line.startswith("Warning: "):
                     # Warning: cannot find svn location for ...
                     continue
@@ -148,6 +144,7 @@ class PipPackage(Pip):
 
     @staticmethod
     def _deprecated():
+        """Raise a `DeprecationWarning`"""
         warnings.warn(
             "Calling host.pip_package is deprecated, call host.pip instead",
             DeprecationWarning,
@@ -156,14 +153,14 @@ class PipPackage(Pip):
     @classmethod
     def check(cls, pip_path="pip"):
         PipPackage._deprecated()
-        return super(PipPackage, cls).check(pip_path=pip_path)
+        return super().check(pip_path=pip_path)
 
     @classmethod
     def get_packages(cls, pip_path="pip"):
         PipPackage._deprecated()
-        return super(PipPackage, cls).get_packages(pip_path=pip_path)
+        return super().get_packages(pip_path=pip_path)
 
     @classmethod
     def get_outdated_packages(cls, pip_path="pip"):
         PipPackage._deprecated()
-        return super(PipPackage, cls).get_outdated_packages(pip_path=pip_path)
+        return super().get_outdated_packages(pip_path=pip_path)

--- a/testinfra/modules/pip.py
+++ b/testinfra/modules/pip.py
@@ -12,8 +12,9 @@
 
 import json
 import re
+import warnings
 
-from testinfra.modules.base import InstanceModule
+from testinfra.modules.base import Module
 
 
 def _re_match(line, regexp):
@@ -23,10 +24,37 @@ def _re_match(line, regexp):
     return match.groups()
 
 
-class PipPackage(InstanceModule):
-    """Test pip packages status and version"""
+class Pip(Module):
+    """Test pip package manager and packages"""
 
-    def check(self, pip_path="pip"):
+    def __init__(self, name, pip_path="pip"):
+        self.name = name
+        self.pip_path = pip_path
+        super().__init__()
+
+    @property
+    def is_installed(self):
+        """Test if the package is installed
+
+        >>> host.package("pip").is_installed
+        True
+        """
+        return self.run_test("{} show %s".format(self.pip_path), self.name).rc == 0
+
+    @property
+    def version(self):
+        """Return package version as returned by pip
+
+        >>> host.package("pip").version
+        '18.1'
+        """
+        return self.check_output(
+            "{} show %s | grep Version: | cut -d' ' -f2".format(self.pip_path),
+            self.name,
+        )
+
+    @classmethod
+    def check(cls, pip_path="pip"):
         """Verify installed packages have compatible dependencies.
 
         >>> cmd = host.pip_package.check()
@@ -42,9 +70,10 @@ class PipPackage(InstanceModule):
         .. _9.0.0: https://pip.pypa.io/en/stable/news/#id526
         """
         cmd = "{} check".format(pip_path)
-        return self.run_expect([0, 1], cmd)
+        return cls.run_expect([0, 1], cmd)
 
-    def get_packages(self, pip_path="pip"):
+    @classmethod
+    def get_packages(cls, pip_path="pip"):
         """Get all installed packages and versions returned by `pip list`:
 
         >>> host.pip_package.get_packages(pip_path='~/venv/website/bin/pip')
@@ -52,7 +81,7 @@ class PipPackage(InstanceModule):
          'mywebsite': {'version': '1.0a3', 'path': '/srv/website'},
          'psycopg2': {'version': '2.6.2'}}
         """
-        out = self.run_expect(
+        out = cls.run_expect(
             [0, 2], "{0} list --no-index --format=json".format(pip_path)
         )
         pkgs = {}
@@ -63,7 +92,7 @@ class PipPackage(InstanceModule):
         else:
             # pip < 9
             output_re = re.compile(r"^(.+) \((.+)\)$")
-            for line in self.check_output(
+            for line in cls.check_output(
                 "{0} list --no-index".format(pip_path)
             ).splitlines():
                 if line.startswith("Warning: "):
@@ -77,14 +106,15 @@ class PipPackage(InstanceModule):
                     pkgs[name] = {"version": version}
         return pkgs
 
-    def get_outdated_packages(self, pip_path="pip"):
+    @classmethod
+    def get_outdated_packages(cls, pip_path="pip"):
         """Get all outdated packages with current and latest version
 
         >>> host.pip_package.get_outdated_packages(
         ...     pip_path='~/venv/website/bin/pip')
         {'Django': {'current': '1.10.2', 'latest': '1.10.3'}}
         """
-        out = self.run_expect([0, 2], "{0} list -o --format=json".format(pip_path))
+        out = cls.run_expect([0, 2], "{0} list -o --format=json".format(pip_path))
         pkgs = {}
         if out.rc == 0:
             for pkg in json.loads(out.stdout):
@@ -100,7 +130,7 @@ class PipPackage(InstanceModule):
                 re.compile(r"^(.+?) \((.+)\) - Latest: (.+) .*$"),
                 re.compile(r"^(.+?) \(Current: (.+) Latest: (.+) .*$"),
             ]
-            for line in self.check_output("{0} list -o".format(pip_path)).splitlines():
+            for line in cls.check_output("{0} list -o".format(pip_path)).splitlines():
                 if line.startswith("Warning: "):
                     # Warning: cannot find svn location for ...
                     continue
@@ -108,3 +138,32 @@ class PipPackage(InstanceModule):
                 name, current, latest = _re_match(line, output_re)
                 pkgs[name] = {"current": current, "latest": latest}
         return pkgs
+
+
+class PipPackage(Pip):
+    """.. deprecated:: 6.2
+
+    Use :class:`~testinfra.modules.pip.Pip` instead.
+    """
+
+    @staticmethod
+    def _deprecated():
+        warnings.warn(
+            "Calling host.pip_package is deprecated, call host.pip instead",
+            DeprecationWarning,
+        )
+
+    @classmethod
+    def check(cls, pip_path="pip"):
+        PipPackage._deprecated()
+        return super(PipPackage, cls).check(pip_path=pip_path)
+
+    @classmethod
+    def get_packages(cls, pip_path="pip"):
+        PipPackage._deprecated()
+        return super(PipPackage, cls).get_packages(pip_path=pip_path)
+
+    @classmethod
+    def get_outdated_packages(cls, pip_path="pip"):
+        PipPackage._deprecated()
+        return super(PipPackage, cls).get_outdated_packages(pip_path=pip_path)


### PR DESCRIPTION
Hello,

As discussed in #605 rename `pip_package` to `pip` and make it works like `package` module e.g:

```python
# instance
django = pip('Django')
assert django.is_installed
assert django.version.startswith('3.1')
# class method
assert pip.check()
```

First implementation of `is_installed` and `version` as properties.

So `Pip` is now a `Module` instead of `InstanceModule` and API not related to a package are implemented as a `classmethod`.

`pip_package` is deprecated with a proper warning (in the code and in the doc) and still works as before.

_shell escaped_ every `pip` calls as suggested by @philpep.

Best