### PR TITLE
Add a magical function testinfra_hosts_update to update host list in runtime

### DIFF
--- a/doc/source/invocation.rst
+++ b/doc/source/invocation.rst
@@ -35,6 +35,12 @@ You can also set hosts per test module::
         [....]
 
 
+If you need to filter or update generated host list (f.e. after ["ansible://somegroup"]),
+you can use testinfra_hosts_update function:
+
+    def testinfra_hosts_update(host_list):
+        return [host_list[0]]
+
 
 Parallel execution
 ~~~~~~~~~~~~~~~~~~

--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -117,6 +117,10 @@ def pytest_generate_tests(metafunc):
             ansible_inventory=metafunc.config.option.ansible_inventory,
             force_ansible=metafunc.config.option.force_ansible,
         )
+        if hasattr(metafunc.module, "testinfra_hosts_update"):
+            if not callable(metafunc.module.testinfra_update.callable):
+                pytest.fail("testinfra_hosts_update must be a function")
+            params = metafunc.module.testinfra_hosts_update(params)
         params = sorted(params, key=lambda x: x.backend.get_pytest_id())
         ids = [e.backend.get_pytest_id() for e in params]
         metafunc.parametrize(


### PR DESCRIPTION
This adds a support for optional magical function `testinfra_hosts_update` to each module, which allows to filter host list after it was created by `testinfra.get_hosts` before doing an actual test parametrization. Practially, it's allow to filter/update/mangle host list after it was become a list of concrete hosts.

The issue it tries to solve is that `testinfra_hosts` when used in tests for molecule/ansible environment usually contains group names (as host names are volatile in many molecule usecases), and some tests may requires to be "run_once" for a given group.

The practical scenario is like this (mons is a groups for Ceph monitors):
```python
testinfra_hosts = ["ansible://mons?force_ansible=True"]

def testinfra_hosts_update(host_list):
    return testinfra[host_list[0]]

def test_cluster_OK(host):
   assert 'HEALTH_OK' in host.check_output('ceph -s').stdout
```