### PR TITLE
Docker version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
 all: doc
 
-DOC_BUILD:=./doc/build/html
-LOCAL_BIND:=127.0.0.1
-
-doc: ## generate documentation
+doc:
 	$(MAKE) -C doc html
 
-serve: ## run a local server to serve the generated doc
-	python -m http.server --bind $(LOCAL_BIND) --directory $(DOC_BUILD)
 
 .PHONY: all doc

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 all: doc
 
-doc:
+DOC_BUILD:=./doc/build/html
+LOCAL_BIND:=127.0.0.1
+
+doc: ## generate documentation
 	$(MAKE) -C doc html
 
+serve: ## run a local server to serve the generated doc
+	python -m http.server --bind $(LOCAL_BIND) --directory $(DOC_BUILD)
 
 .PHONY: all doc

--- a/testinfra/modules/docker.py
+++ b/testinfra/modules/docker.py
@@ -50,6 +50,33 @@ class Docker(Module):
         return self.inspect()["Name"][1:]  # get rid of slash in front
 
     @classmethod
+    def client_version(cls):
+        """Docker client version"""
+        return cls.version("{{.Client.Version}}")
+
+    @classmethod
+    def server_version(cls):
+        """Docker server version"""
+        return cls.version("{{.Server.Version}}")
+
+    @classmethod
+    def version(cls, format=None):
+        """Docker version_ with an optional format (Go template).
+
+        >>> host.docker.version()
+        Client: Docker Engine - Community
+        ...
+        >>> host.docker.version("{{.Client.Context}}"))
+        default
+
+        .. _version: https://docs.docker.com/engine/reference/commandline/version/
+        """
+        cmd = "docker version"
+        if format:
+            cmd = "{} --format '{}'".format(cmd, format)
+        return cls.check_output(cmd)
+
+    @classmethod
     def get_containers(cls, **filters):
         """Return a list of containers
 


### PR DESCRIPTION
Hello,

Implemented a way to get Docker version.

```python
host.docker.client_version()
# 20.10.5
host.docker.server_version()
# 20.10.5
host.docker.version()
# Client: Docker Engine - Community
# Cloud integration: 1.0.9
# ...
host.docker.version("{{.Client.Context}}")
# default
```

**Notes**
- It's [possible in Python `3.9`][1] to combine `@classmethod` and `@property` to get something like that `host.docker.client_version`.
- Are you interested in having an optional `parse` flag implementing [`packaging.version.parse`][2] ? 

```python
from packaging import version
version.parse("2.3.1") < version.parse("10.1.2")
# True

# so giving something like
assert host.docker.server_version(parse=True) > version.parse("19.03")
```
## Bonus

I've added the ability to run a local HTTP server through the `make` in order to check the generated doc locally.

```bash
make doc serve
# ...
# Build finished. The HTML pages are in build/html.
# python -m http.server --bind 127.0.0.1 --directory ./doc/build/html
# Serving HTTP on 127.0.0.1 port 8000 (http://127.0.0.1:8000/) ...
```

Best

[1]: https://stackoverflow.com/a/64738850/4413446
[2]: https://packaging.pypa.io/en/latest/version.html#packaging.version.parse