### PR TITLE
Systemctl show

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -163,6 +163,19 @@ def test_service(host, name, running, enabled):
     service = host.service(name)
     assert service.is_running == running
     assert service.is_enabled == enabled
+    # check with a list
+    props = service.show(["UnitFileState", "ActiveState"])
+    assert props.get("UnitFileState") == "enabled" if enabled else "disabled"
+    assert props.get("ActiveState") in ["active"] if running else ["failed", "inactive"]
+    # check with a single property
+    props = service.show("UnitFileState")
+    assert props.get("UnitFileState") == "enabled" if enabled else "disabled"
+    # check without any property
+    props = service.show()
+    assert props.get("UnitFileState") == "enabled" if enabled else "disabled"
+    # check with something that does not exist
+    props = service.show("DoesNotExist")
+    assert not props, "shall be an empty dict"
 
 
 def test_salt(host):


### PR DESCRIPTION
Hello,

Implementation of `systemctl show` to retrieve the properties of the service (unit) -- implemented only for `systemd`.

Return service properties as a `dict`.
The properties retrieved can be limited to a defined list.

```python
>>> ntp = host.service("ntp")
>>> ntp.show(["FragmentPath", "MainPID"])
{'MainPID': '0', 'FragmentPath': '/lib/systemd/system/ntp.service'}
>>> ntp.show("FragmentPath")
{'FragmentPath': '/lib/systemd/system/ntp.service'}
>>> ntp.show()
{'Type': 'forking', 'Restart': 'no', 'NotifyAccess': 'none', ...
```

Best