### PR TITLE
Interface names and default

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@ mock
 pytest-cov
 pytest-xdist
 paramiko
+types-paramiko
 tornado<5
 salt
 pywinrm

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -684,11 +684,15 @@ def test_interface(host):
     assert host.interface("eth0").exists
     assert not host.interface("does_not_exist").exists
     # adresses
-    for add in host.interface("eth0").addresses:
+    addresses = host.interface.default().addresses
+    assert len(addresses) > 0
+    for add in addresses:
         try:
             ip_address(add)
         except ValueError:
             pytest.fail(f"{add} is not a valid IP address")
     # names and default
     assert "eth0" in host.interface.names()
-    assert host.interface.default() == "eth0"
+    default_itf = host.interface.default()
+    assert default_itf.name == "eth0"
+    assert default_itf.exists

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -18,7 +18,6 @@ import re
 import time
 
 from ipaddress import ip_address
-from ipaddress import ip_network
 from ipaddress import IPv4Address
 from ipaddress import IPv6Address
 
@@ -681,12 +680,15 @@ def test_addr_namespace(host):
 
 
 def test_interface(host):
+    # exist
     assert host.interface("eth0").exists
     assert not host.interface("does_not_exist").exists
-    # default subnet for container networking
-    docker_subnet = ip_network("172.17.0.0/16")
-    for add in map(ip_address, host.interface("eth0").addresses):
-        # Credits to: https://stackoverflow.com/a/59485120/4413446
-        assert docker_subnet.supernet_of(ip_network(f"{add}/{add.max_prefixlen}"))
+    # adresses
+    for add in host.interface("eth0").addresses:
+        try:
+            ip_address(add)
+        except ValueError:
+            pytest.fail(f"{add} is not a valid IP address")
+    # names and default
+    assert "eth0" in host.interface.names()
     assert host.interface.default() == "eth0"
-    assert host.interface.default() in host.interface.names()

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -18,9 +18,9 @@ import re
 import time
 
 from ipaddress import ip_address
+from ipaddress import ip_network
 from ipaddress import IPv4Address
 from ipaddress import IPv6Address
-from ipaddress import ip_network
 
 
 from testinfra.modules.socket import parse_socketspec

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -679,12 +679,16 @@ def test_addr_namespace(host):
         assert not namespace_lookup.port("443").is_reachable
 
 
-def test_interface(host):
+@pytest.mark.parametrize(
+    "family",
+    ["inet", None],
+)
+def test_interface(host, family):
     # exist
-    assert host.interface("eth0").exists
-    assert not host.interface("does_not_exist").exists
+    assert host.interface("eth0", family=family).exists
+    assert not host.interface("does_not_exist", family=family).exists
     # adresses
-    addresses = host.interface.default().addresses
+    addresses = host.interface.default(family).addresses
     assert len(addresses) > 0
     for add in addresses:
         try:
@@ -693,6 +697,6 @@ def test_interface(host):
             pytest.fail(f"{add} is not a valid IP address")
     # names and default
     assert "eth0" in host.interface.names()
-    default_itf = host.interface.default()
+    default_itf = host.interface.default(family)
     assert default_itf.name == "eth0"
     assert default_itf.exists

--- a/testinfra/modules/interface.py
+++ b/testinfra/modules/interface.py
@@ -70,7 +70,7 @@ class Interface(Module):
 
     @classmethod
     def default(cls, family=None):
-        """Return the default interface.
+        """Return the interface used for the default route.
 
         >>> host.interface.default()
         <interface eth0>
@@ -85,9 +85,9 @@ class Interface(Module):
 
 class LinuxInterface(Interface):
     @cached_property
-    def _ip(self, include_family=True):
+    def _ip(self):
         ip_cmd = self.find_command("ip")
-        if include_family and self.family is not None:
+        if self.family is not None:
             ip_cmd = f"{ip_cmd} -f {self.family}"
         return ip_cmd
 

--- a/testinfra/modules/interface.py
+++ b/testinfra/modules/interface.py
@@ -60,10 +60,10 @@ class Interface(Module):
 
     @classmethod
     def default(cls):
-        """Return the name of the default interface.
+        """Return the default interface.
 
         >>> host.interface.default()
-        'eth0'
+        <interface eth0>
         """
         raise NotImplementedError
 
@@ -93,11 +93,12 @@ class LinuxInterface(Interface):
 
     @classmethod
     def default(cls):
-        out = cls.check_output("%s route ls", cls(None)._ip)
+        _default = cls(None)
+        out = cls.check_output("%s route ls", _default._ip)
         for line in out.splitlines():
             if "default" in line:
-                out = line.strip().rsplit(" ", 1)[-1]
-        return out
+                _default.name = line.strip().rsplit(" ", 1)[-1]
+        return _default
 
     @classmethod
     def names(cls):

--- a/testinfra/modules/interface.py
+++ b/testinfra/modules/interface.py
@@ -52,7 +52,7 @@ class Interface(Module):
     @classmethod
     def names(cls):
         """Return the names of all the interfaces.
-        
+
         >>> host.interface.names()
         ['lo', 'tunl0', 'ip6tnl0', 'eth0']
         """
@@ -61,7 +61,7 @@ class Interface(Module):
     @classmethod
     def default(cls):
         """Return the name of the default interface.
-        
+
         >>> host.interface.default()
         'eth0'
         """

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ description = Runs unittests
 deps=
     -rtest-requirements.txt
 commands=
+    {envpython} -m pip install types-paramiko
     {envpython} -m mypy testinfra test
     {envpython} -m pytest {posargs:-v -n 4 --cov testinfra --cov-report xml --cov-report term test}
 usedevelop=True

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ description = Runs unittests
 deps=
     -rtest-requirements.txt
 commands=
-    {envpython} -m pip install types-paramiko
     {envpython} -m mypy testinfra test
     {envpython} -m pytest {posargs:-v -n 4 --cov testinfra --cov-report xml --cov-report term test}
 usedevelop=True


### PR DESCRIPTION
Hello,

First try to resolve #613.
@rgarrigue not sure if it matches your expectations.

```python
# all interfaces
host.interface.names()
# ['lo', 'tunl0', 'ip6tnl0', 'eth0']

# default interface
default_itf = host.interface.default()
default_itf.name
# 'eth0'
default_itf.addresses
# ['172.17.0.3']
```

It's a work in progress. Open to suggestions and improvements either in the naming and in the implementation.

Best