### PR TITLE
Rename adresses to addresses

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -687,7 +687,7 @@ def test_interface(host, family):
     # exist
     assert host.interface("eth0", family=family).exists
     assert not host.interface("does_not_exist", family=family).exists
-    # adresses
+    # addresses
     addresses = host.interface.default(family).addresses
     assert len(addresses) > 0
     for add in addresses:

--- a/testinfra/modules/interface.py
+++ b/testinfra/modules/interface.py
@@ -22,7 +22,7 @@ class Interface(Module):
 
     Optionally, the protocol family to use can be enforced.
 
-    >>> host.interface("eth0", "inet6").adresses
+    >>> host.interface("eth0", "inet6").addresses
     ['fe80::e291:f5ff:fe98:6b8c']
     """
 

--- a/testinfra/modules/socket.py
+++ b/testinfra/modules/socket.py
@@ -96,7 +96,7 @@ class Socket(Module):
 
         >>> host.socket("unix:///var/run/docker.sock").is_listening
         False
-        >>> # This HTTP server listen on all ipv4 adresses but not on ipv6
+        >>> # This HTTP server listen on all ipv4 addresses but not on ipv6
         >>> host.socket("tcp://0.0.0.0:80").is_listening
         True
         >>> host.socket("tcp://:::80").is_listening
@@ -127,7 +127,7 @@ class Socket(Module):
     def clients(self) -> List[Optional[Tuple[str, int]]]:
         """Return a list of clients connected to a listening socket
 
-        For tcp and udp sockets a list of pair (adress, port) is returned.
+        For tcp and udp sockets a list of pair (address, port) is returned.
         For unix sockets a list of None is returned (thus you can make a
         len() for counting clients).
 
@@ -254,7 +254,7 @@ class LinuxSocketSS(Socket):
             elif protocol in ("tcp", "udp"):
                 host, port = local.rsplit(":", 1)
                 port = int(port)
-                # new versions of ss output ipv6 adresses enclosed in []
+                # new versions of ss output ipv6 addresses enclosed in []
                 if host and host[0] == "[" and host[-1] == "]":
                     host = host[1:-1]
             else:


### PR DESCRIPTION
Fix Issue [#616 AttributeError: 'LinuxInterface' object has no attribute 'adresses'](https://github.com/pytest-dev/pytest-testinfra/issues/616)