### PR TITLE
Use RpmPackage on CentOS and Fedora and not only on CentOS

### DIFF
--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -70,9 +70,12 @@ class Package(Module):
             return OpenBSDPackage
         if host.system_info.distribution in ("debian", "ubuntu"):
             return DebianPackage
-        if (
-            host.system_info.distribution
-            and host.system_info.distribution.lower() == "centos"
+        if host.system_info.distribution and (
+            host.system_info.distribution.lower()
+            in (
+                "centos",
+                "fedora",
+            )
         ):
             return RpmPackage
         if host.system_info.distribution == "arch":


### PR DESCRIPTION
On Fedora you can also install dpkg, which will cause testinfra to think that
the package manager is actually DPKG and not RPM. Thus we instead use the
system_info.distribution value to prefer rpm on Fedora