### PR TITLE
Fix the CI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=1.3
 alabaster>=0.7.2
-hacking
+hacking>=4.0
 .

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -54,7 +54,7 @@ def test_package(host, docker_image):
     assert ssh.is_installed
     assert ssh.version.startswith(version)
     release = {
-        "alpine": "r2",
+        "alpine": "r3",
         "archlinux": None,
         "centos_7": ".el7",
         "debian_bullseye": None,

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv=HOME TRAVIS DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY WSL_DISTRO_NA
 description = Performs linting tasks
 deps=
   flake8
-  hacking
+  hacking>=4.0
   flake8-bugbear
   flake8-comprehensions
   flake8-debugger


### PR DESCRIPTION
Two tiny changes to make the CI green again:
- bump release of the test package in the Alpine image
- force a more recent version of the hacking plugin