### PR TITLE
Support older busybox

### DIFF
--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -61,6 +61,9 @@ class File(Module):
         >>> host.file("/var/lock").linked_to
         '/run/lock'
         """
+        res = self.run_expect([0, 127], "realpath %s", self.path)
+        if res.rc == 0:
+            return res.stdout.strip()
         return self.check_output("readlink -f %s", self.path)
 
     @property


### PR DESCRIPTION
Testinfra uses `readlink -f` and `command -v` which are both not supported by older versions of busybox. However this can be worked around by using `realpath` and `which`, respectively.