### PR TITLE
ansible: Support SSH args from environment

### DIFF
--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -101,6 +101,20 @@ def get_ansible_host(config, inventory, host, ssh_config=None, ssh_identity_file
             },
             "environment": "ANSIBLE_REMOTE_PORT",
         },
+        "ansible_ssh_common_args": {
+            "ini": {
+                "section": "ssh_connection",
+                "key": "ssh_common_args",
+            },
+            "environment": "ANSIBLE_SSH_COMMON_ARGS",
+        },
+        "ansible_ssh_extra_args": {
+            "ini": {
+                "section": "ssh_connection",
+                "key": "ssh_extra_args",
+            },
+            "environment": "ANSIBLE_SSH_EXTRA_ARGS",
+        },
         "ansible_user": {
             "ini": {
                 "section": "defaults",
@@ -149,8 +163,8 @@ def get_ansible_host(config, inventory, host, ssh_config=None, ssh_identity_file
     kwargs["ssh_extra_args"] = " ".join(
         [
             config.get("ssh_connection", "ssh_args", fallback=""),
-            hostvars.get("ansible_ssh_common_args", ""),
-            hostvars.get("ansible_ssh_extra_args", ""),
+            get_config("ansible_ssh_common_args", ""),
+            get_config("ansible_ssh_extra_args", ""),
         ]
     ).strip()
 


### PR DESCRIPTION
As an extension of #627, this commit adds the ability to get
`ansible_ssh_common_args` and `ansible_ssh_extra_args` from the configuration
file or environment variables, with the expected precedence:

| Configuration File                      | Host Variable             | Environment               |
| --------------------------------------- | ------------------------- | ------------------------- |
| `[ssh_connection]`<br>`ssh_common_args` | `ansible_ssh_common_args` | `ANSIBLE_SSH_COMMON_ARGS` |
| `[ssh_connection]`<br>`ssh_extra_args`  | `ansible_ssh_extra_args`  | `ANSIBLE_SSH_EXTRA_ARGS`  |

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>