### PR TITLE
host.py: Fix "which" fallback in find_command

### DIFF
--- a/testinfra/host.py
+++ b/testinfra/host.py
@@ -44,7 +44,7 @@ class Host:
         if out.rc == 0:
             return out.stdout.rstrip("\r\n")
         if out.rc == 127:
-            out = self.run_expect([0, 1], "which %s", self.path)
+            out = self.run_expect([0, 1], "which %s", command)
             if out.rc == 0:
                 return out.stdout.rstrip("\r\n")
         for basedir in extrapaths:


### PR DESCRIPTION
Commit "Fallback to which when command -v fails" has changed things to call which(1) in find_command
but used "self.path" has argument to which(1), leading to:

E       AttributeError: 'Host' object has no attribute 'path'

Update the call to pass "command" as argument.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>