### PR TITLE
add ssh_extra_args option

### DIFF
--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -66,7 +66,7 @@ This is a pure SSH backend using the ``ssh`` command. Example::
     $ py.test --ssh-config=/path/to/ssh_config --hosts='ssh://server'
     $ py.test --ssh-identity-file=/path/to/key --hosts='ssh://server'
     $ py.test --hosts='ssh://server?timeout=60&controlpersist=120'
-
+    $ py.test --hosts='ssh://server' --ssh-extra-args='-o StrictHostKeyChecking=no'
 
 By default timeout is set to 10 seconds and ControlPersist is set to 60 seconds.
 You can disable persistent connection by passing `controlpersist=0` to the options.

--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -60,6 +60,12 @@ def pytest_addoption(parser):
         help="SSH config file",
     )
     group.addoption(
+        "--ssh-extra-args",
+        action="store",
+        dest="ssh_extra_args",
+        help="SSH extra args",
+    )
+    group.addoption(
         "--ssh-identity-file",
         action="store",
         dest="ssh_identity_file",


### PR DESCRIPTION
This is follow up to https://github.com/pytest-dev/pytest-testinfra/commit/b749619fbd28a90c3e323fa66b2329aff60facf4 and seems related to https://github.com/pytest-dev/pytest-testinfra/issues/467 but does not solve it:

Expose the ssh_extra_options as a pytest CLI option. This is already accepted as a kwarg to the ssh backend. My use-case was to disable SSH host key checking, I was able to work-around it via a configfile but this seemed like a nice feeature to expose up as its own option, and comments in #467 seem to indicate this was the intent.