### PR TITLE
Handle ansible_connection type community.docker.docker

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -285,6 +285,15 @@ def test_ansible_get_variables():
         ),
         (
             {},
+            b"host ansible_connection=community.docker.docker",
+            {
+                "NAME": "docker",
+                "name": "host",
+                "user": None,
+            },
+        ),
+        (
+            {},
             b"host ansible_connection=docker ansible_become=yes ansible_become_user=u ansible_user=z ansible_host=container",
             {  # noqa
                 "NAME": "docker",

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -68,12 +68,14 @@ def get_ansible_host(config, inventory, host, ssh_config=None, ssh_identity_file
         "paramiko_ssh",
         "local",
         "docker",
+        "community.docker.docker",
         "lxc",
         "lxd",
     ):
         # unhandled connection type, must use force_ansible=True
         return None
     connection = {
+        "community.docker.docker": "docker",
         "lxd": "lxc",
         "paramiko_ssh": "paramiko",
         "smart": "ssh",


### PR DESCRIPTION
Molecule's Docker driver sets `ansible_connection` to
`community.docker.docker`, making
`testinfra.utils.ansible_runner.AnsibleRunner.get_host` fail to return
such a host in a Molecule test using the Docker driver.

Fix this by translating "community.docker.docker" to "docker".

Closes #648.