### PR TITLE
get_encoding: if python3 not found, failback

### DIFF
--- a/testinfra/backend/base.py
+++ b/testinfra/backend/base.py
@@ -252,22 +252,24 @@ class BaseBackend(metaclass=abc.ABCMeta):
 
     def get_encoding(self) -> str:
         encoding = None
-        for python in ("python3", "python"):
-            cmd = self.run(
-                "%s -c 'import locale;print(locale.getpreferredencoding())'",
-                python,
-                encoding=None,
-            )
-            if cmd.rc == 0:
-                encoding = cmd.stdout_bytes.splitlines()[0].decode("ascii")
-                break
-        # Python is not installed, we hope the encoding to be the same as
-        # local machine...
-        if not encoding:
-            encoding = locale.getpreferredencoding()
-        if encoding == "ANSI_X3.4-1968":
-            # Workaround default encoding ascii without LANG set
-            encoding = "UTF-8"
+        try:
+            for python in ("python3", "python"):
+                cmd = self.run(
+                    "%s -c 'import locale;print(locale.getpreferredencoding())'",
+                    python,
+                    encoding=None,
+                )
+                if cmd.rc == 0:
+                    encoding = cmd.stdout_bytes.splitlines()[0].decode("ascii")
+                    break
+        except:
+            # Python is not installed, we hope the encoding to be the same as
+            # local machine...
+            if not encoding:
+                encoding = locale.getpreferredencoding()
+            if encoding == "ANSI_X3.4-1968":
+                # Workaround default encoding ascii without LANG set
+                encoding = "UTF-8"
         return encoding
 
     @property


### PR DESCRIPTION
When i wants to use ansible backend on windows host, i have a problem with ascii decode

Use `ansible.windows.win_service_info` to retrieve all services 

```python
def test_services(host):
    res = host.ansible(
        "ansible.windows.win_service_info", "", check=False
    )
    for service in res['services']:
        print(f"DEBUG {service['name']}")
```

result:
```
self = <encodings.ascii.IncrementalDecoder object at 0x7f695f40dfa0>
input = b'{"changed": false, "exists": true, "services": [{"checkpoint": 0, "controls_accepted": [], "dependencies": [], "depe...4d", "type": "network_endpoint"}], "username": "NT AUTHORITY\\\\SYSTEM", "wait_hint_ms": 0, "win32_exit_code": 1077}]}'
final = True

    def decode(self, input, final=False):
>       return codecs.ascii_decode(input, self.errors)[0]
E       UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 72968: ordinal not in range(128)
```

On windows, a service "Function Discovery Provider Host" contains a description with `Web Services – Discovery`  (character 'En Dash', U+2013) 
a 'En dash' character in service description .... 

I'm using Ansible backend on windows, python don't install on it.

I add a try/except on `backend/base.py` to failback on `locale.getpreferredencoding()`