### PR TITLE
Add support for Manjaro-Linux, really closes #503

### DIFF
--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -81,7 +81,7 @@ class Package(Module):
             )
         ):
             return RpmPackage
-        if host.system_info.distribution == "arch":
+        if host.system_info.distribution in ("arch", "manjarolinux"):
             return ArchPackage
         if host.exists("apk"):
             return AlpinePackage

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -31,7 +31,7 @@ class Package(Module):
 
         - apk (Alpine)
         - apt (Debian, Ubuntu, ...)
-        - pacman (Arch)
+        - pacman (Arch, Manjaro )
         - pkg (FreeBSD)
         - pkg_info (NetBSD)
         - pkg_info (OpenBSD)


### PR DESCRIPTION
Why treat manjarolinux <=> arch different than 
e.g. debian <=> ubuntu 
or fedora <=>  centos
==> 
Add support for ManjaroLinux via detection of distribution