### PR TITLE
Add basic docu for file.contains

### DIFF
--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -116,6 +116,9 @@ class File(Module):
         raise NotImplementedError
 
     def contains(self, pattern):
+        """Checks content of file for pattern. This uses grep and thus follows the grep
+        regex syntax.
+        """  # noqa
         return self.run_test("grep -qs -- %s %s", pattern, self.path).rc == 0
 
     @property

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -116,9 +116,10 @@ class File(Module):
         raise NotImplementedError
 
     def contains(self, pattern):
-        """Checks content of file for pattern. This uses grep and thus follows the grep
-        regex syntax.
-        """  # noqa
+        """Checks content of file for pattern
+
+        This uses grep and thus follows the grep regex syntax.
+        """
         return self.run_test("grep -qs -- %s %s", pattern, self.path).rc == 0
 
     @property


### PR DESCRIPTION
When using this today, I struggled to find how this works in the documentation. This hopefully gives some pointers for people how to structure their pattern. I wanted to find out how to search for "term1" or "term2" which in gnu grep (or extended grep in other grep versions) would be "term1\|term2" but didn't include this as this depends too much on the grep used. Feel free to change or ask for improvements. Not fully satisfied yet and did this via web so not sure if flake8 is happy.