### PR TITLE
Remove PytestDeprecationWarning about config opts

### DIFF
--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -189,7 +189,7 @@ class SpooledTemporaryFile(tempfile.SpooledTemporaryFile):
         return super().write(s)
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config):
     if config.getoption("--verbose", 0) > 1:
         root = logging.getLogger()
@@ -207,7 +207,7 @@ def pytest_configure(config):
             config.pluginmanager.register(NagiosReporter(out), "nagiosreporter")
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
     reporter = session.config.pluginmanager.getplugin("nagiosreporter")
     if reporter:


### PR DESCRIPTION
Pytest has deprecated markers for hooks configuration. See: https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers

Each envocation of pytest with python warning enabled would produce the following message:
PytestDeprecationWarning: The hookimpl pytest_configure uses old-style configuration options (marks or attributes).

Please use the pytest.hookimpl(trylast=True) decorator instead

This commit fixes that issue.