### PR TITLE
Conditional Check Hardlink to Busybox Binary

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -350,6 +350,16 @@ def test_file(host):
     assert f == host.file("/d/f")
     assert not d == f
 
+    host.check_output("ln /d/f /d/h")
+    hardlink = host.file("/d/h")
+    assert hardlink.is_file
+    assert not hardlink.is_symlink
+    assert isinstance(hardlink.inode, int)
+    assert isinstance(f.inode, int)
+    assert hardlink.inode == f.inode
+    assert f == host.file("/d/f")
+    assert not d == f
+
     host.check_output("rm -f /d/p && mkfifo /d/p")
     assert host.file("/d/p").is_pipe
 

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -237,6 +237,10 @@ class GNUFile(File):
         return int(self.check_output("stat -c %%s %s", self.path))
 
     @property
+    def inode(self):
+        return int(self.check_output("stat -c %%i %s", self.path))
+
+    @property
     def md5sum(self):
         return self.check_output("md5sum %s | cut -d' ' -f1", self.path)
 

--- a/testinfra/modules/process.py
+++ b/testinfra/modules/process.py
@@ -109,8 +109,9 @@ class Process(InstanceModule):
     def get_module_class(cls, host):
         if host.file("/bin/ps").linked_to == "/bin/busybox":
             return BusyboxProcess
-        if host.file("/bin/ps").inode == host.file("/bin/busybox").inode:
-            return BusyboxProcess
+        if host.file("/bin/busybox").exists:
+            if host.file("/bin/ps").inode == host.file("/bin/busybox").inode:
+                return BusyboxProcess
         if host.system_info.type == "linux" or host.system_info.type.endswith("bsd"):
             return PosixProcess
         raise NotImplementedError

--- a/testinfra/modules/process.py
+++ b/testinfra/modules/process.py
@@ -109,6 +109,8 @@ class Process(InstanceModule):
     def get_module_class(cls, host):
         if host.file("/bin/ps").linked_to == "/bin/busybox":
             return BusyboxProcess
+        if host.file("/bin/ps").inode == host.file("/bin/busybox").inode:
+            return BusyboxProcess
         if host.system_info.type == "linux" or host.system_info.type.endswith("bsd"):
             return PosixProcess
         raise NotImplementedError


### PR DESCRIPTION
Links to Busybox can be hardlinks as well, an example is the [Prometheus node exporter Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter). `get_module_class` is not sufficient in this case.
Therefore, to identify a hardlink, property `inode` is implemented as a GNUFile property. The added condition compares Inodes of `/bin/ps` and `/bin/busybox` as well as the simple existance of busybox itself. Some testcases for the hardlink check via `inode` property were created in `test/test_modules.py`.