### PR TITLE
delegate_to fixture to allow delegation from within test

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -179,3 +179,30 @@ fixture.
     def test_myimage(host):
         # 'host' now binds to the container
         assert host.check_output('myapp -v') == 'Myapp 1.0'
+
+.. _using delegation:
+
+Using delegation
+~~~~~~~~~~~~~~~~
+
+If testinfra is used with Ansible backend, it is possible to delegate
+to another host using `delegate_to` fixture.
+
+.. code-block:: python
+
+    @pytest.mark.testinfra_hosts("ansible://foo")
+    def test_bar_configured_with_foo(host, delegate_to):
+        foo_config = host.check_output("foo --get-foo")
+        bar_host = delegate_to("ansible://bar")
+        assert bar_host.check_output(f"bar --check {foo_config}") == "OK"
+
+
+.. code-block:: python
+
+    testinfra_hosts = ["ansible://foo"]
+
+    # this test is not dependent on testinfra_hosts value
+    # because it's not using 'host' fixture.
+    def test_skip_if_empty(delegate_to):
+        bar_host = delegate_to("ansible://bar", skip_empty=True)
+            assert bar_host.check_output(f"foobar")

--- a/doc/source/invocation.rst
+++ b/doc/source/invocation.rst
@@ -65,3 +65,23 @@ For more usages and features, see the Pytest_ documentation.
 
 .. _Pytest: https://docs.pytest.org/en/latest/
 .. _pytest-xdist: https://pypi.org/project/pytest-xdist/
+
+Delegation
+~~~~~~~~~~
+
+If testinfra is used with Ansible backend, it is possible to create
+another Host object using `delegate_to` fixture. This fixture is a function
+which can produce a new Host object based on `host_specs` parameter
+(e.g. "ansible://foo" or "ansible://bar?force_ansible").
+
+It can delegate only to one host (no parametrization), so fixture fail
+if there are more than one host resolved from host_specs to host list.
+
+If host_specs resolves to empty list, fixture either fail test
+or skip it, depending on value of optional parameter `skip_empty`
+(default value is False, meaning 'fail the test if hostlist is empty').
+
+With `skip_empty=True` (i.e. `delegate_to("ansible://foo", skip_empty=True)`,
+if there are no hosts for a given host_specs, test is skipped.
+
+See :ref:`Using delegation` for examples.

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -427,6 +427,19 @@ def test_ansible_module_become(host):
 
 
 @pytest.mark.testinfra_hosts("ansible://debian_bullseye")
+def test_delegate_to_existing_group(host, delegate_to):
+    delegated_host = delegate_to(
+        "ansible://user@debian_bullseye"
+    )  # reuse the same host with different hostspec as 'different host'
+    assert host.user().name != delegated_host.user().name
+
+
+def test_without_host(delegate_to):
+    delegated_host = delegate_to("ansible://debian_bullseye")
+    assert host.check_output("uptime")
+
+
+@pytest.mark.testinfra_hosts("ansible://debian_bullseye")
 def test_ansible_module_options(host):
     assert (
         host.ansible(


### PR DESCRIPTION
delegate_to is a fixture-function which allow to create new Host objects inside test.

Rationale: There are services where tests, aiming to one host, need to query something or test something on a different host (like a cluster primary, centralized monitoring, etc).

Ansible has a nice idea of task delegation (add `delegate_to: foobar`, and this task is run on another host with the same variables as original host). Adding `delegate_to` into pytest allows to use the same pattern for tests.

Examples:

```python

    @pytest.mark.testinfra_hosts("ansible://foo")
    def test_bar_configured_with_foo(host, delegate_to):
        foo_config = host.check_output("foo --get-foo")
        bar_host = delegate_to("ansible://bar")
        assert bar_host.check_output(f"bar --check {foo_config}") == "OK"
```

```python

    # this test is not dependent on testinfra_hosts value
    # because it's not using 'host' fixture.
    def test_skip_if_empty(delegate_to):
        bar_host = delegate_to("ansible://bar", skip_empty=True)
            assert bar_host.check_output(f"foobar")
```