### PR TITLE
Add File.is_executable

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -363,6 +363,10 @@ def test_file(host):
     host.check_output("rm -f /d/p && mkfifo /d/p")
     assert host.file("/d/p").is_pipe
 
+    host.check_output("chmod 700 /d/f")
+    assert f.is_executable
+    assert f.mode == 0o700
+
 
 def test_ansible_unavailable(host):
     expected = "Ansible module is only available with " "ansible connection backend"

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -36,10 +36,12 @@ class File(Module):
 
     @property
     def is_file(self):
+        """Test if the path is a regular file"""
         return self.run_test("test -f %s", self.path).rc == 0
 
     @property
     def is_directory(self):
+        """Test if the path exists and a directory"""
         return self.run_test("test -d %s", self.path).rc == 0
 
     @property
@@ -49,14 +51,17 @@ class File(Module):
 
     @property
     def is_pipe(self):
+        """Test if the path exists and is a pipe"""
         return self.run_test("test -p %s", self.path).rc == 0
 
     @property
     def is_socket(self):
+        """Test if the path exists and is a socket"""
         return self.run_test("test -S %s", self.path).rc == 0
 
     @property
     def is_symlink(self):
+        """Test if the path exists and is a symbolic link"""
         return self.run_test("test -L %s", self.path).rc == 0
 
     @property
@@ -91,10 +96,12 @@ class File(Module):
 
     @property
     def group(self):
+        """Return file group name as string"""
         raise NotImplementedError
 
     @property
     def gid(self):
+        """Return file group id as integer"""
         raise NotImplementedError
 
     @property
@@ -129,10 +136,12 @@ class File(Module):
 
     @property
     def md5sum(self):
+        """Compute the MD5 message digest of the file content"""
         raise NotImplementedError
 
     @property
     def sha256sum(self):
+        """Compute the SHA256 message digest of the file content"""
         raise NotImplementedError
 
     def _get_content(self, decode):

--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -43,6 +43,11 @@ class File(Module):
         return self.run_test("test -d %s", self.path).rc == 0
 
     @property
+    def is_executable(self):
+        """Test if the path exists and permission to execute is granted"""
+        return self.run_test("test -x %s", self.path).rc == 0
+
+    @property
     def is_pipe(self):
         return self.run_test("test -p %s", self.path).rc == 0
 


### PR DESCRIPTION
Hi,

this PR contains `File.is_executable` and some additional docstrings.

This simplified the check if a script/program is executable

```
f = host.file('/path/to/myscript')
assert f.is_executable
```

instead of
```
f = host.file('/path/to/myscript')
assert f.exists and f.mode == 0o700
```


Regards,
Carsten