### PR TITLE
Workaround Docker#42442 by using IPv4 SSH only

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -113,7 +113,13 @@ def build_docker_container_fixture(image, scope):
         request.addfinalizer(teardown)
 
         port = check_output("docker port %s 22", docker_id)
-        port = int(port.rsplit(":", 1)[-1])
+        # IPv4 addresses seem to be reported consistently
+        # in the first line of the output.
+        # To workaround https://github.com/moby/moby/issues/42442
+        # use only the values of the first line of the command
+        # output
+        port = int(port.splitlines()[0].rsplit(":", 1)[-1])
+
         return docker_id, docker_host, port
 
     fname = "_docker_container_{}_{}".format(image, scope)


### PR DESCRIPTION
As described in https://github.com/moby/moby/issues/42442, docker daemon starts to expose a container port on different host ports for IPv4 and IPv6 which breaks the ssh/safe-ssh/ansible backend tests for some containers.
To prevent this behavior and flaky tests, only the first line from the `docker port %s 22` command gets parsed to acquire the mapped SSH port.