### PR TITLE
pre-commit: update isort to 5.12.0 to silence import error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: debug-statements
         language_version: python3
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args:


### PR DESCRIPTION
Running tox results in an error message:

> Configuration is invalid:
>        - [extras.pipfile_deprecated_finder.2] \
>          'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'

This is caused by additional checks in poetry-core >= 1.5.0 and fixed fixed by https://github.com/PyCQA/isort/pull/2078