### PR TITLE
Improve system detection for openSUSE style distributions

### DIFF
--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -77,6 +77,8 @@ class Package(Module):
                 "centos",
                 "cloudlinux",
                 "fedora",
+                "opensuse-leap",
+                "opensuse-tumbleweed",
                 "rocky",
             )
         ):

--- a/testinfra/modules/systeminfo.py
+++ b/testinfra/modules/systeminfo.py
@@ -50,21 +50,6 @@ class SystemInfo(InstanceModule):
     def _get_linux_sysinfo(self):
         sysinfo = {}
 
-        # LSB
-        lsb = self.run("lsb_release -a")
-        if lsb.rc == 0:
-            for line in lsb.stdout.splitlines():
-                key, value = line.split(":", 1)
-                key = key.strip().lower()
-                value = value.strip().lower()
-                if key == "distributor id":
-                    sysinfo["distribution"] = value
-                elif key == "release":
-                    sysinfo["release"] = value
-                elif key == "codename":
-                    sysinfo["codename"] = value
-            return sysinfo
-
         # https://www.freedesktop.org/software/systemd/man/os-release.html
         os_release = self.run("cat /etc/os-release")
         if os_release.rc == 0:
@@ -98,6 +83,21 @@ class SystemInfo(InstanceModule):
         if alpine_release.rc == 0:
             sysinfo["distribution"] = "alpine"
             sysinfo["release"] = alpine_release.stdout.strip()
+            return sysinfo
+
+        # LSB
+        lsb = self.run("lsb_release -a")
+        if lsb.rc == 0:
+            for line in lsb.stdout.splitlines():
+                key, value = line.split(":", 1)
+                key = key.strip().lower()
+                value = value.strip().lower()
+                if key == "distributor id":
+                    sysinfo["distribution"] = value
+                elif key == "release":
+                    sysinfo["release"] = value
+                elif key == "codename":
+                    sysinfo["codename"] = value
             return sysinfo
 
         return sysinfo


### PR DESCRIPTION
openSUSE distributions can have rpm, dnf and dpkg installed at the same time, but the system is always maintained via rpm. so explicitly detect it as such. Also don't trust lsb-release too much, /etc/os-release is the preferred method so pick that one first. 