### PR TITLE
Ansible: Fix for missing group names in get_variables()

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -190,7 +190,7 @@ def test_ansible_get_variables():
             "a": "a",
             "e": "f",
             "inventory_hostname": "rockylinux",
-            "group_names": ["ungrouped"],
+            "group_names": ["all", "ungrouped"],
             "groups": groups,
         }
 

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -183,7 +183,7 @@ def test_ansible_get_variables():
             "c": "d",
             "x": "z",
             "inventory_hostname": "debian",
-            "group_names": ["g"],
+            "group_names": ["all", "g"],
             "groups": groups,
         }
         assert get_vars("rockylinux") == {

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -348,7 +348,7 @@ def test_ansible_module(host):
     assert variables["myhostvar"] == "bar"
     assert variables["mygroupvar"] == "qux"
     assert variables["inventory_hostname"] == "debian_bookworm"
-    assert variables["group_names"] == ["testgroup"]
+    assert variables["group_names"] == ["all", "testgroup"]
     assert variables["groups"] == {
         "all": ["debian_bookworm"],
         "testgroup": ["debian_bookworm"],

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -301,12 +301,14 @@ class AnsibleRunner:
         hostvars.setdefault("inventory_hostname", host)
         group_names = []
         groups = {}
+
         for group in sorted(inventory):
             if group == "_meta":
                 continue
             groups[group] = sorted(itergroup(inventory, group))
-            if group != "all" and host in inventory[group].get("hosts", []):
+            if host in groups[group]:
                 group_names.append(group)
+
         hostvars.setdefault("group_names", group_names)
         hostvars.setdefault("groups", groups)
         return hostvars


### PR DESCRIPTION
The Ansible variable group names contains all groups the host is part of and not only the direct parent groups, this is a fix to reflect how ansible works.


Link to documentation:
- https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html#term-group_names