### PR TITLE
Use new key to specify license file in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description = file:README.rst
 long_description_content_type = text/x-rst
 author = Philippe Pepiot
 author_email = phil@philpep.org
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console


### PR DESCRIPTION
to prevent deprecation warning.

Please check next builds that the license file is always included as the new metadata works only for wheels - not sdists.