### PR TITLE
testinfra/modules/blockdevice: Don't fail on stderr

### DIFF
--- a/testinfra/modules/blockdevice.py
+++ b/testinfra/modules/blockdevice.py
@@ -130,7 +130,7 @@ class LinuxBlockDevice(BlockDevice):
         header = ["RO", "RA", "SSZ", "BSZ", "StartSec", "Size", "Device"]
         command = "blockdev  --report %s"
         blockdev = self.run(command, self.device)
-        if blockdev.rc != 0 or blockdev.stderr:
+        if blockdev.rc != 0:
             raise RuntimeError("Failed to gather data: {}".format(blockdev.stderr))
         output = blockdev.stdout.splitlines()
         if len(output) < 2:


### PR DESCRIPTION
The `blockdevice` module raises a `RuntimeError` if `blockdev` returns with a non-zero exit code, or if stderr is not empty.

But the latter can happen even when there's no failure at all, for instance if `sshd` has a banner message configured (which gets output to stderr whenever someone connects to the host).