### PR TITLE
Teaching GNUFile methods to follow symlinks

### DIFF
--- a/testinfra/modules/file.py
+++ b/testinfra/modules/file.py
@@ -223,38 +223,38 @@ class File(Module):
 class GNUFile(File):
     @property
     def user(self):
-        return self.check_output("stat -c %%U %s", self.path)
+        return self.check_output("stat -Lc %%U %s", self.path)
 
     @property
     def uid(self):
-        return int(self.check_output("stat -c %%u %s", self.path))
+        return int(self.check_output("stat -Lc %%u %s", self.path))
 
     @property
     def group(self):
-        return self.check_output("stat -c %%G %s", self.path)
+        return self.check_output("stat -Lc %%G %s", self.path)
 
     @property
     def gid(self):
-        return int(self.check_output("stat -c %%g %s", self.path))
+        return int(self.check_output("stat -Lc %%g %s", self.path))
 
     @property
     def mode(self):
         # Supply a base of 8 when parsing an octal integer
         # e.g. int('644', 8) -> 420
-        return int(self.check_output("stat -c %%a %s", self.path), 8)
+        return int(self.check_output("stat -Lc %%a %s", self.path), 8)
 
     @property
     def mtime(self):
-        ts = self.check_output("stat -c %%Y %s", self.path)
+        ts = self.check_output("stat -Lc %%Y %s", self.path)
         return datetime.datetime.fromtimestamp(float(ts))
 
     @property
     def size(self):
-        return int(self.check_output("stat -c %%s %s", self.path))
+        return int(self.check_output("stat -Lc %%s %s", self.path))
 
     @property
     def inode(self):
-        return int(self.check_output("stat -c %%i %s", self.path))
+        return int(self.check_output("stat -Lc %%i %s", self.path))
 
     @property
     def md5sum(self):


### PR DESCRIPTION
On Linux systems, if `File.mode` is used on a file that's a symlink, it will return `0x777` because that's the _mode_ of the symlink but mode is pretty meaningless for a symlink.  By doing `stat -L ...` the command will automatically resolve symlinks.

I know there is the BSDFile implementation too but I don't believe I have access to a BSD system to try things out.

This addresses a problem where testinfra is used to get information on a target file but you don't want to worry about whether a symbolic link is involved - it's irrelevant.  There are examples of symlinks in the Amazon Linux 2023 container:
```
$ docker run -it --rm amazonlinux:2023
Unable to find image 'amazonlinux:2023' locally
2023: Pulling from library/amazonlinux
1db371c0a72a: Pull complete
Digest: sha256:355f1638075375e4db3a0f7aa9cd73f79fb1a738b72035bc66a3cfda30e0053b
Status: Downloaded newer image for amazonlinux:2023
bash-5.2# ls -ld /etc/issue
lrwxrwxrwx 1 root root 16 Dec 13 00:00 /etc/issue -> ../usr/lib/issue
bash-5.2# stat /etc/issue
  File: /etc/issue -> ../usr/lib/issue
  Size: 16              Blocks: 0          IO Block: 4096   symbolic link
Device: 37h/55d Inode: 4903000     Links: 1
Access: (0777/lrwxrwxrwx)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2023-12-13 00:00:03.000000000 +0000
Modify: 2023-12-13 00:00:03.000000000 +0000
Change: 2023-12-20 11:54:00.744190148 +0000
 Birth: 2023-12-20 11:54:00.744190148 +0000
bash-5.2# stat -c %a /etc/issue
777
bash-5.2# ls -Lld /etc/issue
-rw-r--r-- 1 root root 28 Dec 13 00:00 /etc/issue
bash-5.2# stat -L /etc/issue
  File: /etc/issue
  Size: 28              Blocks: 8          IO Block: 4096   regular file
Device: 37h/55d Inode: 4904219     Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2023-12-13 00:00:03.000000000 +0000
Modify: 2023-12-13 00:00:03.000000000 +0000
Change: 2023-12-20 11:54:00.992194752 +0000
 Birth: 2023-12-20 11:54:00.992194752 +0000
bash-5.2# stat -Lc %a /etc/issue
644
bash-5.2#
```

I ran the tests via `tox` and they all passed.

This is my first pytest-testinfra pull request and I would be happy to rework it however it needs to be done.
