### PR TITLE
Import future annotations for pytest 6, Python 3.9 compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ packages = find:
 setup_requires =
     setuptools_scm
 install_requires =
-    pytest!=3.0.2
+    pytest>=6
 extras_require =
 
 [options.extras_require]

--- a/testinfra/plugin.py
+++ b/testinfra/plugin.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 import shutil
 import sys


### PR DESCRIPTION
Makes testinfra v10.0.0 work with Python 3.9 and pytest 6.2.2, which is being used in CentOS-Stream-9-based distributions.
 
Resolves #755.