### PR TITLE
Improved RpmPackage is_installed property logic.

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -65,7 +65,7 @@ def test_rpmdb_corrupted(host):
     with pytest.raises(RuntimeError) as excinfo:
         host.package("zsh").is_installed
     assert (
-        f"Could not check if RPM package 'zsh' is installed. "
+        "Could not check if RPM package 'zsh' is installed. "
         "error: sqlite failure:"
     ) in str(excinfo.value)
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -58,19 +58,16 @@ def test_held_package(host):
     assert python.is_installed
     assert python.version.startswith("3.11.")
 
+@pytest.mark.destructive
 @pytest.mark.testinfra_hosts("docker://rockylinux9")
 def test_rpmdb_corrupted(host):
-    host.check_output("mv /var/lib/rpm/rpmdb.sqlite /var/lib/rpm/rpmdb.sqlite.bck")
-    try:
-        host.check_output("dd if=/dev/zero of=/var/lib/rpm/rpmdb.sqlite bs=1024 count=1")
-        with pytest.raises(RuntimeError) as excinfo:
-            host.package("zsh").is_installed
-        assert (
-            f"Could not check if RPM package 'zsh' is installed. "
-            "error: sqlite failure:"
-        ) in str(excinfo.value)
-    finally:
-        host.check_output("mv /var/lib/rpm/rpmdb.sqlite.bck /var/lib/rpm/rpmdb.sqlite")
+    host.check_output("dd if=/dev/zero of=/var/lib/rpm/rpmdb.sqlite bs=1024 count=1")
+    with pytest.raises(RuntimeError) as excinfo:
+        host.package("zsh").is_installed
+    assert (
+        f"Could not check if RPM package 'zsh' is installed. "
+        "error: sqlite failure:"
+    ) in str(excinfo.value)
 
 @pytest.mark.testinfra_hosts("docker://rockylinux9")
 def test_non_default_package_tool(host):

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -58,6 +58,19 @@ def test_held_package(host):
     assert python.is_installed
     assert python.version.startswith("3.11.")
 
+@pytest.mark.destructive
+@pytest.mark.testinfra_hosts("docker://rockylinux9")
+def test_rpm_package_broken_db(host):
+    with host.sudo():
+        # Corrupt RPM database so that we make RpmPackage.is_installed throw an exception
+        host.run_test('rpm --rebuilddb')
+        host.run_test('dd if=/dev/zero of=$(rpm --dbpath)/Packages bs=1024 count=1024 seek=1024')
+    with pytest.raises(RuntimeError) as excinfo:
+        host.package("zsh").is_installed
+    assert (
+        "DB_PAGE_NOT_FOUND"
+        in str(excinfo.value)
+    )
 
 @pytest.mark.testinfra_hosts("docker://rockylinux9")
 def test_non_default_package_tool(host):

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -58,6 +58,7 @@ def test_held_package(host):
     assert python.is_installed
     assert python.version.startswith("3.11.")
 
+
 @pytest.mark.destructive
 @pytest.mark.testinfra_hosts("docker://rockylinux9")
 def test_rpmdb_corrupted(host):
@@ -65,9 +66,9 @@ def test_rpmdb_corrupted(host):
     with pytest.raises(RuntimeError) as excinfo:
         host.package("zsh").is_installed
     assert (
-        "Could not check if RPM package 'zsh' is installed. "
-        "error: sqlite failure:"
+        "Could not check if RPM package 'zsh' is installed. error: sqlite failure:"
     ) in str(excinfo.value)
+
 
 @pytest.mark.testinfra_hosts("docker://rockylinux9")
 def test_non_default_package_tool(host):

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -13,7 +13,6 @@
 import crypt
 import datetime
 import os
-from unittest import mock
 import re
 import time
 from ipaddress import IPv4Address, IPv6Address, ip_address

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -58,19 +58,16 @@ def test_held_package(host):
     assert python.is_installed
     assert python.version.startswith("3.11.")
 
-@pytest.mark.destructive
 @pytest.mark.testinfra_hosts("docker://rockylinux9")
-def test_rpm_package_broken_db(host):
-    with host.sudo():
-        # Corrupt RPM database so that we make RpmPackage.is_installed throw an exception
-        host.run_test('rpm --rebuilddb')
-        host.run_test('dd if=/dev/zero of=$(rpm --dbpath)/Packages bs=1024 count=1024 seek=1024')
+def test_rpm_package_not_installed(host):
+    # Pass an invalid value as package name, it returns exit code 1
+    pkg_name = "-3"
     with pytest.raises(RuntimeError) as excinfo:
-        host.package("zsh").is_installed
+        host.package(pkg_name).is_installed
     assert (
-        "DB_PAGE_NOT_FOUND"
-        in str(excinfo.value)
-    )
+        f"Could not check if RPM package '{pkg_name}' is installed. "
+        f"rpm: {pkg_name}: unknown option"
+    ) in str(excinfo.value)
 
 @pytest.mark.testinfra_hosts("docker://rockylinux9")
 def test_non_default_package_tool(host):

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -165,7 +165,7 @@ class OpenBSDPackage(Package):
 class RpmPackage(Package):
     @property
     def is_installed(self):
-        result = self.run("rpm -q --quiet %s 2>&1", self.name)
+        result = self.run_test("rpm -q --quiet %s 2>&1", self.name)
         if result.succeeded:
             return True
         elif result.failed and result.stdout == '':

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -168,10 +168,12 @@ class RpmPackage(Package):
         result = self.run_test("rpm -q --quiet %s 2>&1", self.name)
         if result.succeeded:
             return True
-        elif result.failed and result.stdout == '':
+        elif result.failed and result.stdout == "":
             return False
         else:
-            raise RuntimeError(f"Could not check if RPM package '{self.name}' is installed. {result.stdout}")
+            raise RuntimeError(
+                f"Could not check if RPM package '{self.name}' is installed. {result.stdout}"
+            )
 
     @property
     def version(self):

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -165,14 +165,13 @@ class OpenBSDPackage(Package):
 class RpmPackage(Package):
     @property
     def is_installed(self):
-        result = self.run("rpm -q %s", self.name)
+        result = self.run("rpm -q --quiet %s 2>&1", self.name)
         if result.succeeded:
             return True
-
-        if "not installed" in result.stdout or not result.stdout.startswith(self.name):
+        elif result.failed and result.stdout == '':
             return False
-
-        raise RuntimeError(f"Could not check if RPM package '{self.name}' is installed. {result}")
+        else:
+            raise RuntimeError(f"Could not check if RPM package '{self.name}' is installed. {result.stdout}")
 
     @property
     def version(self):

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -169,12 +169,10 @@ class RpmPackage(Package):
         if result.succeeded:
             return True
 
-        if "not installed" in result.stdout:
+        if "not installed" in result.stdout or not result.stdout.startswith(self.name):
             return False
 
-        raise RuntimeError(
-            "Could not check if RPM package '{}' is installed. {}".format(self.name, result)
-        )
+        raise RuntimeError(f"Could not check if RPM package '{self.name}' is installed. {result}")
 
     @property
     def version(self):

--- a/testinfra/modules/package.py
+++ b/testinfra/modules/package.py
@@ -165,7 +165,16 @@ class OpenBSDPackage(Package):
 class RpmPackage(Package):
     @property
     def is_installed(self):
-        return self.run_test("rpm -q %s", self.name).rc == 0
+        result = self.run("rpm -q %s", self.name)
+        if result.succeeded:
+            return True
+
+        if "not installed" in result.stdout:
+            return False
+
+        raise RuntimeError(
+            "Could not check if RPM package '{}' is installed. {}".format(self.name, result)
+        )
 
     @property
     def version(self):


### PR DESCRIPTION
This new logic verifies if there is a "not installed" string in the stdout when "rpm -q %s" command returns 1.

As seen in bug #758, if rpm command failed because of other reasons (such as database corruption), the old implementation was returning True, making the end-user think that the package was installed, however it was never queried.