### PR TITLE
Fix service.exists

### DIFF
--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -176,7 +176,7 @@ class SystemdService(SysvService):
 
     @property
     def exists(self):
-        cmd = self.run_test('systemctl list-unit-files | grep -q"^%s"', self.name)
+        cmd = self.run_test('systemctl list-unit-files | grep -q "^%s"', self.name)
         return cmd.rc == 0
 
     @property


### PR DESCRIPTION
service.exists fail with systemd because there was a typo in the underlying command, missing a space between grep option `-q` and service name.

This PR fixes that problem

This fixes #768 