### PR TITLE
Adding additional potential systemctl exit status for Ubuntu 24

### DIFF
--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -181,7 +181,7 @@ class SystemdService(SysvService):
 
     @property
     def is_running(self):
-        out = self.run_expect([0, 1, 3], "systemctl is-active %s", self.name)
+        out = self.run_expect([0, 1, 3, 4], "systemctl is-active %s", self.name)
         if out.rc == 1:
             # Failed to connect to bus: No such file or directory
             return super().is_running


### PR DESCRIPTION
This is a simple change to `SystemdService.is_running()` to allow it to work for Ubuntu 24 to correct the symptoms in #775. 

On Ubuntu 24, `systemctl is-activate foobar` (assuming `foobar` is an unknown service) has an exit status of 4 but the `is_running()` method only expects exit status values of 0, 1, or 3.  My change just allows an exit status of 4 as well.  The method will return `False` anyway but it won't raise the `AssertionError`.

I was following `CONTRIBUTING.rst` and tried running `tox` from a virtual environment on my development machine but it failed and I'm not sure how to fix it.  Here's the output: [tox output.txt](https://github.com/user-attachments/files/16998670/tox.output.txt).
