### PR TITLE
Fix KeyError in MountPoint.__repr__()

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -482,12 +482,14 @@ def test_supervisor(host, supervisorctl_path, supervisorctl_conf):
 def test_mountpoint(host):
     root_mount = host.mount_point("/")
     assert root_mount.exists
+    assert repr(root_mount)
     assert isinstance(root_mount.options, list)
     assert "rw" in root_mount.options
     assert root_mount.filesystem
 
     fake_mount = host.mount_point("/fake/mount")
     assert not fake_mount.exists
+    assert repr(fake_mount)
 
     mountpoints = host.mount_point.get_mountpoints()
     assert mountpoints

--- a/testinfra/modules/mountpoint.py
+++ b/testinfra/modules/mountpoint.py
@@ -101,13 +101,17 @@ class MountPoint(Module):
         raise NotImplementedError
 
     def __repr__(self):
+        if self.exists:
+            d = self.device
+            f = self.filesystem
+            o = ",".join(self.options)
+        else:
+            d = ""
+            f = ""
+            o = ""
         return (
-            "<MountPoint(path={}, device={}, filesystem={}, " "options={})>"
-        ).format(
-            self.path,
-            self.device,
-            self.filesystem,
-            ",".join(self.options),
+            f'<MountPoint(path="{self.path}", exists={self.exists}, device="{d}", '
+            f'filesystem="{f}", options="{o}") at 0x{id(self):08x}>'
         )
 
 


### PR DESCRIPTION
`MountPoint.__repr__()` triggered a KeyError exception if the mount point doesn't exist. The commit below fixes this problem.

Solved error:
```
__________________ test_mountpoint[docker://debian_bookworm] ___________________
[gw1] linux -- Python 3.9.20 /home/runner/work/pytest-testinfra/pytest-testinfra/.tox/py39/bin/python

host = <testinfra.host.Host docker://debian_bookworm>

    def test_mountpoint(host):
        root_mount = host.mount_point("/")
        assert root_mount.exists
        assert repr(root_mount)
        assert isinstance(root_mount.options, list)
        assert "rw" in root_mount.options
        assert root_mount.filesystem
    
        fake_mount = host.mount_point("/fake/mount")
        assert not fake_mount.exists
>       assert repr(fake_mount)

test/test_modules.py:492: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
testinfra/modules/mountpoint.py:108: in __repr__
    self.device,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[KeyError('device') raised in repr()] LinuxMountPoint object at 0x7fa72d956b80>

    @property
    def device(self):
        """Return the device associated
    
        >>> host.mount_point("/").device
        '/dev/sda1'
    
        """
>       return self._attrs["device"]
E       KeyError: 'device'

testinfra/modules/mountpoint.py:70: KeyError
```

