### PR TITLE
allow to limit ansible hosts with regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ flake8.report
 junit*.xml
 doc/build
 .cache
+.idea/

--- a/test/inventory.yml
+++ b/test/inventory.yml
@@ -1,0 +1,33 @@
+all:
+  hosts:
+    s1:
+      ansible_host: 192.168.1.1
+    s2:
+      ansible_host: 192.168.1.2
+    s3:
+      ansible_host: 192.168.1.3
+    s4:
+      ansible_host: 192.168.1.4
+    s5:
+      ansible_host: 192.168.1.5
+    s6:
+      ansible_host: 192.168.1.6
+    s7:
+      ansible_host: 192.168.1.7
+    s8:
+      ansible_host: 192.168.1.8
+    s9:
+      ansible_host: 192.168.1.9
+
+  children:
+    servers:
+      hosts:
+        s1:
+        s2:
+        s3:
+        s4:
+        s5:
+        s6:
+        s7:
+        s8:
+        s9:

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -523,6 +523,14 @@ def test_docker_encoding(host):
 def test_parse_hostspec(hostspec, expected):
     assert BaseBackend.parse_hostspec(hostspec) == expected
 
+@pytest.mark.parametrize(
+    "hostspec,expected",
+    [
+        ("ansible://host1", ('host1', {'connection': 'ansible'})),
+    ],
+)
+def test_init_parse_hostspec(hostspec, expected):
+    assert testinfra.backend.parse_hostspec(hostspec) == expected
 
 @pytest.mark.parametrize(
     "hostspec,pod,container,namespace,kubeconfig,context",
@@ -641,6 +649,16 @@ def test_get_hosts():
         ("a", 1),
     ]
 
+
+def test_get_hosts_ansible_limit():
+    # Hosts returned by get_host must be deduplicated (by name & kwargs) and in
+    # same order as asked
+    hosts = testinfra.backend.get_backends(
+        [
+            "ansible://s%5B1-4%5D%2A?ansible_inventory=inventory.yml" # s%5B1-4%5D%2A == s[1-4]*
+        ]
+    )
+    assert [h.hostname for h in hosts] == ["s1", "s2", "s3", "s4"]
 
 @pytest.mark.testinfra_hosts(*HOSTS)
 def test_command_deadlock(host):

--- a/testinfra/backend/__init__.py
+++ b/testinfra/backend/__init__.py
@@ -96,6 +96,7 @@ def get_backends(
     backends = {}
     for hostspec in hosts:
         host, kw = parse_hostspec(hostspec)
+        host = urllib.parse.unquote(host)
         for k, v in kwargs.items():
             kw.setdefault(k, v)
         connection = kw.get("connection")


### PR DESCRIPTION
Hello, I have added simple change `urllib.parse.unquote(host)` for host variable to allow using regex.

I think is kinda not the best way, I was thinking about option `--ansible-limit` and in `ansble.py` we could change method `get_hosts` as follows:

```python
    @classmethod
    def get_hosts(cls, host: str, **kwargs: Any) -> list[str]:
        inventory = kwargs.get("ansible_inventory")
        hosts = AnsibleRunner.get_runner(inventory).get_hosts(host or "all")
        if kwargs.get("ansible_limit"):
            # Filter hosts based on the limit expression
            from ansible.parsing.dataloader import DataLoader
            from ansible.inventory.manager import InventoryManager

            loader = DataLoader()
            inventory_manager = InventoryManager(loader=loader, sources=inventory)
            limited_hosts = inventory_manager.get_hosts( pattern=kwargs.get("ansible_limit"))
            return [host for host in inventory if
                    host.name in [h.name for h in limited_hosts]]
        else:
            return hosts
```

what do you think?