### PR TITLE
Applying technique from #773 to is_enabled property

### DIFF
--- a/testinfra/modules/service.py
+++ b/testinfra/modules/service.py
@@ -194,7 +194,7 @@ class SystemdService(SysvService):
 
     @property
     def is_enabled(self):
-        cmd = self.run_test("systemctl is-enabled %s", self.name)
+        cmd = self.run_expect([0, 1, 3, 4], "systemctl is-enabled %s", self.name)
         if cmd.rc == 0:
             return True
         if cmd.stdout.strip() == "disabled":


### PR DESCRIPTION
This applies the same technique from #773 to the `is_running` property of the `SystemdService` class of `testinfra/modules/service.py` to fix #801.

I tried following the steps from `CONTRIBUTING.rst` but got some errors from tox while installing `timelib`: [tox-output.txt](https://github.com/user-attachments/files/19587017/tox-output.txt).  Are there prerequisites I'm missing?  Can `CONTRIBUTING.rst` be improved?