### PR TITLE
Arbitrary host expressions for Ansible backend

### DIFF
--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -194,6 +194,51 @@ https://docs.ansible.com/ansible/latest/reference_appendices/config.html
 * ``ANSIBLE_BECOME_USER``
 * ``ANSIBLE_BECOME``
 
+Advanced hosts expressions for ansible
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to use most of the
+`Ansible host expressions <https://docs.ansible.com/ansible/latest/inventory_guide/intro_patterns.html>`
+in Testinfra.
+
+Supported:
+
+* ``&``, ``!``, ``,``, ``:``
+* glob expressions (``server*`` with match server1, server2, etc)
+* ranges (``[x:y]``) are supported with replacement with round brackets.
+  ``mygroup[1:2]`` should be written as ``mygroup(1:2)``, this is due to limitation
+  of what is allowed in the host part of the URL.
+  When host expression is passed to ansible for parsing, ``()`` are replaced with
+  ``[]``.
+
+Regular expressions (starting with '~') are not supported due to limitations
+for allowed characters in the host part of the URL.
+
+When testinfra parses host expressions, it choose:
+
+* A simple resolver, if there is no host expression (e.g. a single group,
+  hostname, or glob pattern)
+* Ansible resolver, which covers most cases. It requires to have ansible-core
+  been present on the controller (host, where pytest is running). It imports
+  part of ansible to do expression evaluation, os it's slower.
+
+Examples of the simple host expression (Ansible is not used for parsing):
+
+* ``ansible://debian_bookworm``
+* ``ansible://user@debian_bookworm?force_ansible=True&sudo=True``
+* ``ansible://host*``
+
+Examples of the Ansible-parsed host expressions:
+
+* ``ansible://group1,!group3`` (hosts in group1 but not in group3)
+* ``ansible://group1(0)`` (the first host in the group). This can be used as a substitute
+  for run_once.
+* ``ansible://group1,&group3`` (hosts in both group1 and group2)
+* ``ansible://group1,group2,!group3,example*`` (hosts in group1 or group2 but not
+  in group3, and hosts matching regular expression ``(example1.*)``)
+* ``ansible://group1,group2,!group3,example*?force_ansible=True&sudo=True``
+  (the same, but forcing Ansible backend and adds sudo)
+
 kubectl
 ~~~~~~~
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,3 +19,6 @@ ignore_missing_imports = True
 
 [mypy-setuptools_scm.*]
 ignore_missing_imports = True
+
+[mypy-ansible.*]
+ignore_missing_imports = True

--- a/test/test_ansible_host_expressions.py
+++ b/test/test_ansible_host_expressions.py
@@ -1,0 +1,99 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+
+import pytest
+
+from testinfra.utils.ansible_runner import AnsibleRunner
+
+INVENTORY = b"""
+---
+group1:
+  hosts:
+    host1:
+    host2:
+group2:
+  hosts:
+    host3:
+    host4:
+group3:
+  hosts:
+    host1:
+    host4:
+group4:
+   hosts:
+    example1:
+    example11:
+    example2:
+"""
+
+
+@pytest.fixture(scope="module")
+def get_hosts():
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(INVENTORY)
+        f.flush()
+
+        def _get_hosts(spec):
+            return AnsibleRunner(f.name).get_hosts(spec)
+
+        yield _get_hosts
+
+
+@pytest.fixture(scope="function")
+def get_env_var():
+    old_value = os.environ.get("ANSIBLE_INVENTORY")
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(INVENTORY)
+        f.flush()
+        os.environ["ANSIBLE_INVENTORY"] = f.name
+
+        def _get_env_hosts(spec):
+            return AnsibleRunner(None).get_hosts(spec)
+
+        yield _get_env_hosts
+    if old_value:
+        os.environ["ANSIBLE_INVENTORY"] = old_value
+    else:
+        del os.environ["ANSIBLE_INVENTORY"]
+
+
+def test_ansible_host_expressions_index(get_hosts):
+    assert get_hosts("group1(0)") == ["host1"]
+
+
+def test_ansible_host_expressions_negative_index(get_hosts):
+    assert get_hosts("group1(-1)") == ["host2"]
+
+
+def test_ansible_host_expressions_not(get_hosts):
+    assert get_hosts("group1,!group3") == ["host2"]
+
+
+def test_ansible_host_expressions_and(get_hosts):
+    assert get_hosts("group1,&group3") == ["host1"]
+
+
+def test_ansible_host_complicated_expression(get_hosts):
+    expression = "group1,group2,!group3,example1*"
+    assert set(get_hosts(expression)) == {"host2", "host3", "example1", "example11"}
+
+
+def test_ansible_host_regexp(get_hosts):
+    with pytest.raises(ValueError):
+        get_hosts("~example1*")
+
+
+def test_ansible_host_with_ansible_inventory_env_var(get_env_var):
+    assert set(get_env_var("host1,example1*")) == {"host1", "example1", "example11"}

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands=
 description = Performs typing check
 extras =
   typing
+  ansible
 usedevelop=True
 commands=
   mypy


### PR DESCRIPTION
Ansible has extensive so-called host expressions: ability to join/exclude hosts from a host list based on logical expressions:

Examples:

* `database,&primary` -  hosts in database and primary groups
* `database,!standby` - hosts in database group but not in standby group
* `database[0]` - first host in the group

Full list is here: https://docs.ansible.com/ansible/latest/inventory_guide/intro_patterns.html

testnfra lacked this ability for long time (see #609, rejected, where I was asked to bring patterns).

I've decided to try to implement them. Implementing from scratch is very hard (see link above to see all features and complexity). I've tried to reuse ansible code (specifically, InventoryManager, which allows evaluation of the host expressions). Proper support for InventoryManager also required to add ConfigManager (I wanted to keep full support for `ANSIBLE_INVENTORY` environment var which I use a lot for many testcases).

I understand, that bringing `from ansible import ..` could break a lot of things, so instead of 'switching to Ansible for everything', I've added a simple heuristic:

* older features (like normal groups and globs for host names) are going to work old way (keeping all existing tests running as before).
* Only if host expression is containing signs of complicated expression, switch to ansible. This will limit breakage due to possible ansible drift, only to tests, which are dependent on complex expressions.

## Host expression problem

I also found, that `ansible://groupname[0]` is not valid uri ([] is reserved for IPv6 addreses in the host part of the URI). I thought about possible workarounds, and the least invasive was to replace `ansible://groupname[0]` with `ansible://groupname(0)`. Slightly odd, but perfectly readable and limited only to the specific case.

Limitations for possible characters in 'host' part of URI is also the reason why regexp (~) can not be supported this way, unfortunately.
