### PR TITLE
Allow VSOCK as Ansible host

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -214,6 +214,13 @@ def test_ansible_get_variables():
         ),
         (
             {},
+            b"host ansible_host=vsock%555",
+            {
+                "host.name": "vsock%555",
+            },
+        ),
+        (
+            {},
             b"host ansible_connection=smart",
             {
                 "NAME": "ssh",

--- a/testinfra/utils/ansible_runner.py
+++ b/testinfra/utils/ansible_runner.py
@@ -17,6 +17,7 @@ import ipaddress
 import json
 import os
 import tempfile
+import urllib.parse
 from collections.abc import Iterator
 from typing import Any, Callable, Optional, Union
 
@@ -214,7 +215,7 @@ def get_ansible_host(
     if version == 6:
         spec += "[" + testinfra_host + "]"
     else:
-        spec += testinfra_host
+        spec += urllib.parse.quote(testinfra_host)
     if port:
         spec += f":{port}"
     return testinfra.get_host(spec, **kwargs)


### PR DESCRIPTION
From https://man.archlinux.org/man/vsock.7:
> The VSOCK address family facilitates communication between virtual machines and the host they are running on.

An example: https://wiki.archlinux.org/title/QEMU#Accessing_SSH_via_vsock

The separator between the "vsock" identifier and the CID can either be a forward slash (`/`) or a percent sign (`%`). `urllib.parse.urlparse` will mistake the forward slash for the beginning of the URL path, but a percent sign is accepted.

```python
>>> urlparse("ansible://vsock/555")
ParseResult(scheme='ansible', netloc='vsock', path='/555', params='', query='', fragment='')
>>> urlparse("ansible://vsock%555")
ParseResult(scheme='ansible', netloc='vsock%555', path='', params='', query='', fragment='')
```