### PR TITLE
Preserve explicit Paramiko username

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -632,12 +632,12 @@ def test_paramiko_ssh_config_does_not_override_explicit_user():
 
     backend = ParamikoBackend("explicit@example.com")
     cfg = {"username": backend.host.user}
-    backend._load_ssh_config(object(), cfg, ssh_config)  # type: ignore[arg-type]
+    backend._load_ssh_config(paramiko.SSHClient(), cfg, ssh_config)
     assert cfg["username"] == "explicit"
 
     backend = ParamikoBackend("example.com")
     cfg = {"username": backend.host.user}
-    backend._load_ssh_config(object(), cfg, ssh_config)  # type: ignore[arg-type]
+    backend._load_ssh_config(paramiko.SSHClient(), cfg, ssh_config)
     assert cfg["username"] == "configuser"
 
 

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -13,6 +13,7 @@
 import operator
 import os
 import tempfile
+from io import StringIO
 
 import pytest
 
@@ -619,6 +620,25 @@ def test_ssh_hostspec(hostspec, expected):
     cmd, cmd_args = backend._build_ssh_command("true")
     command = backend.quote(" ".join(cmd), *cmd_args)
     assert command == expected
+
+
+def test_paramiko_ssh_config_does_not_override_explicit_user():
+    import paramiko
+
+    from testinfra.backend.paramiko import ParamikoBackend
+
+    ssh_config = paramiko.SSHConfig()
+    ssh_config.parse(StringIO("Host *\n  User configuser\n"))
+
+    backend = ParamikoBackend("explicit@example.com")
+    cfg = {"username": backend.host.user}
+    backend._load_ssh_config(object(), cfg, ssh_config)  # type: ignore[arg-type]
+    assert cfg["username"] == "explicit"
+
+    backend = ParamikoBackend("example.com")
+    cfg = {"username": backend.host.user}
+    backend._load_ssh_config(object(), cfg, ssh_config)  # type: ignore[arg-type]
+    assert cfg["username"] == "configuser"
 
 
 def test_get_hosts():

--- a/testinfra/backend/paramiko.py
+++ b/testinfra/backend/paramiko.py
@@ -68,7 +68,8 @@ class ParamikoBackend(base.BaseBackend):
             if key == "hostname":
                 cfg[key] = value
             elif key == "user":
-                cfg["username"] = value
+                if cfg.get("username") is None:
+                    cfg["username"] = value
             elif key == "port":
                 cfg[key] = int(value)
             elif key == "identityfile":


### PR DESCRIPTION
Fixes #643.

When Paramiko loads ssh config defaults, a `Host *` user should not replace a username that was already supplied in the host spec, like `paramiko://vagrant@127.0.0.1:2222`.

This keeps the ssh config user fallback for host specs without a user, and adds a small regression test for both paths.

Checked with:

```
uv run --with paramiko python -
uv run --with ruff ruff check testinfra/backend/paramiko.py test/test_backends.py
uv run --with mypy --with types-paramiko --with paramiko --with pytest mypy testinfra/backend/paramiko.py
```

I also tried the focused pytest test on Windows, but this repo's test conftest hits Docker probing before collection and currently trips a Windows bytes-args issue in the local backend, so I verified the Paramiko config path directly instead.