### PR TITLE
Show GitHub stars in docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -125,6 +125,7 @@ html_theme_options = {
     "github_user": "pytest-dev",
     "github_repo": "pytest-testinfra",
     "github_button": True,
+    "github_type": "star",
     "extra_nav_links": {
         "View on github": "https://github.com/pytest-dev/pytest-testinfra",
     },


### PR DESCRIPTION
Closes #813.

Configures the Alabaster GitHub button to show stars instead of watchers.

Checks: sphinx-build -W -b html doc/source doc/build; pre-commit on doc/source/conf.py; git diff --check.