### PR TITLE
fix: handle ansible encoding errors and update rocky9 package assertion

### DIFF
--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -87,7 +87,8 @@ def test_encoding(host):
     elif host.backend.get_connection_type() == "ansible" and host.backend.force_ansible:
         # XXX: this encoding issue comes directly from ansible
         # not sure how to handle this...
-        assert (
+        assert cmd.failed
+        assert "surrogates not allowed" in cmd.stderr or (
             cmd.stderr
             == "ls: impossible d'acc\udce9der \udce0 '/é': Aucun fichier ou dossier de ce type"
         )

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -39,7 +39,7 @@ def test_package(host, docker_image):
     assert not host.package("zsh").is_installed
     ssh = host.package("openssh-server")
     version = {
-        "rockylinux9": "8.",
+        "rockylinux9": "9.",
         "debian_bookworm": "1:9.2",
     }[docker_image]
     assert ssh.is_installed

--- a/testinfra/backend/ansible.py
+++ b/testinfra/backend/ansible.py
@@ -61,11 +61,16 @@ class AnsibleBackend(base.BaseBackend):
             data = json.loads(out["module_stdout"])
             stdout = data["stdout"]
             stderr = data["stderr"]
-        else:
+        elif "stdout" in out:
             # bw compat
             stdout = out["stdout"]
             stderr = out["stderr"]
-        return self.result(out["rc"], self.encode(command), stdout, stderr)
+        else:
+            # Ansible command failed (e.g. encoding error) with only a msg
+            stdout = ""
+            stderr = out.get("msg", "")
+        rc = out.get("rc", 1)
+        return self.result(rc, self.encode(command), stdout, stderr)
 
     def run_ansible(
         self, module_name: str, module_args: Optional[str] = None, **kwargs: Any


### PR DESCRIPTION
## Summary

Fixes CI failures in the `build (py311)` job:

### 1. Handle Ansible encoding errors gracefully (`testinfra/backend/ansible.py`)

When Ansible fails to run a command (e.g., due to UTF-8 surrogate encoding issues), it returns a response with only a `msg` key and no `stdout`/`stderr`. Previously this caused a `KeyError: 'stdout'`. Now the code:
- Checks for `module_stdout` (new ansible format)
- Falls back to `stdout` (backward compat)
- Falls back to `msg` for error responses, placed in `stderr`
- Uses `.get("rc", 1)` since `rc` may also be missing

### 2. Make encoding test resilient to Ansible version differences (`test/test_backends.py`)

The `test_encoding[ansible://debian_bookworm?force_ansible=True]` test now accepts either the old-style `ls` error message with surrogates (older ansible) or the new surrogate-rejection transport error from newer ansible versions. Also asserts `cmd.failed is True`.

### 3. Update Rocky Linux 9 package version expectation (`test/test_modules.py`)

The rocky linux 9 docker image now ships `openssh-server 9.9p1` instead of 8.x. Updated version prefix from `"8."` to `"9."`.

---

Fixes CI run: https://github.com/pytest-dev/pytest-testinfra/actions/runs/26749425227